### PR TITLE
Configurable waku host and port with fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /.idea
 /.fleet
 /examples/target
-boot_node_id.conf
+boot_node_addr.conf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3377,7 +3377,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "waku-bindings"
 version = "0.1.0-beta1"
-source = "git+https://github.com/waku-org/waku-rust-bindings?rev=d4136fd#d4136fd72bbeb39d65b90bba336d564f760cb9cb"
+source = "git+https://github.com/waku-org/waku-rust-bindings?rev=0fb4e2e#0fb4e2e917629143608654cb3762efb78bff8ca2"
 dependencies = [
  "aes-gcm",
  "base64 0.13.1",
@@ -3396,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "waku-sys"
 version = "0.1.0-beta1"
-source = "git+https://github.com/waku-org/waku-rust-bindings?rev=d4136fd#d4136fd72bbeb39d65b90bba336d564f760cb9cb"
+source = "git+https://github.com/waku-org/waku-rust-bindings?rev=0fb4e2e#0fb4e2e917629143608654cb3762efb78bff8ca2"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords=["graphprotocol", "gossip network", "sdk"]
 categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
-waku = { package = "waku-bindings", git = "https://github.com/waku-org/waku-rust-bindings", rev="d4136fd" }
+waku = { package = "waku-bindings", git = "https://github.com/waku-org/waku-rust-bindings", rev="0fb4e2e" }
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"

--- a/examples/poi-crosschecker/src/graphql/mod.rs
+++ b/examples/poi-crosschecker/src/graphql/mod.rs
@@ -46,7 +46,6 @@ pub async fn query_graph_node_poi(
     if let Some(data) = response_body.data {
         match data.proof_of_indexing {
             Some(poi) => Ok(poi),
-            // _ => Ok("0xa6008cea5905b8b7811a68132feea7959b623188e2d6ee3c87ead7ae56dd0eae".to_string()),
             _ => Err(QueryError::EmptyResponseError),
             // _ => Ok(std::env::args().nth(1).unwrap_or("welllllp".to_string())),
         }

--- a/examples/poi-crosschecker/src/main.rs
+++ b/examples/poi-crosschecker/src/main.rs
@@ -32,6 +32,9 @@ async fn main() {
     let private_key = env::var("PRIVATE_KEY").expect("No private key provided.");
     let eth_node = env::var("ETH_NODE").expect("No ETH URL provided.");
 
+    // Option for where to host the waku node instance
+    let waku_host = env::var("WAKU_HOST").ok();
+    let waku_port = env::var("WAKU_PORT").ok();
     // Send message every x blocks for which wait y blocks before attestations
     let examination_frequency = 3;
     let wait_block_duration = 2;
@@ -39,7 +42,7 @@ async fn main() {
     let provider: Provider<Http> = Provider::<Http>::try_from(eth_node.clone()).unwrap();
     let radio_name: &str = "poi-crosschecker";
 
-    let gossip_agent = GossipAgent::new(private_key, eth_node, radio_name)
+    let gossip_agent = GossipAgent::new(private_key, eth_node, radio_name, waku_host, waku_port)
         .await
         .unwrap();
 

--- a/src/gossip_agent/mod.rs
+++ b/src/gossip_agent/mod.rs
@@ -63,6 +63,8 @@ impl GossipAgent {
         private_key: String,
         eth_node: String,
         radio_name: &str,
+        waku_host: Option<String>,
+        waku_port: Option<String>,
     ) -> Result<GossipAgent, Box<dyn Error>> {
         let wallet = private_key.parse::<LocalWallet>().unwrap();
         let provider: Provider<Http> = Provider::<Http>::try_from(eth_node.clone()).unwrap();
@@ -84,7 +86,10 @@ impl GossipAgent {
                                      // .collect::<Vec<&str>>()[1..2].to_vec();
 
         let content_topics = build_content_topics(radio_name, 0, &subtopics);
-        let node_handle = setup_node_handle(&content_topics);
+        //Should we allow the setting of waku node host and port?
+        let host = waku_host.as_deref();
+        let port = waku_port.map(|y| y.parse().unwrap());
+        let node_handle = setup_node_handle(&content_topics, host, port);
         Ok(GossipAgent {
             wallet,
             eth_node,


### PR DESCRIPTION
### Description
Factor out waku node configurations for the difference between boot nodes (enable relay and filter protocol, waiting for bindings to support `isFilterFullNode`), and light nodes (only enable filter protocol with filter subscription). 
Favor storing boot node `Multiaddr` rather than `peer_id` for the later structuring of ENR tree.
Allow configuration such that users can decide where to host and port the nodes particularly when managing multiple node instances.

### Issue link (if applicable)
Improvement to #23 
