### PR TITLE
Persistence node addr for DNS discovery with static list fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,6 +1404,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "colored",
+ "data-encoding",
  "ethers",
  "ethers-contract",
  "ethers-core",
@@ -1416,11 +1417,13 @@ dependencies = [
  "partial_application",
  "prost",
  "reqwest",
+ "secp256k1 0.25.0",
  "serde",
  "serde_derive",
  "serde_json",
  "thiserror",
  "tokio",
+ "url",
  "waku-bindings",
 ]
 
@@ -2750,8 +2753,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9512ffd81e3a3503ed401f79c33168b9148c75038956039166cd750eaa037c3"
 dependencies = [
  "rand",
- "secp256k1-sys",
+ "secp256k1-sys 0.6.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "550fc3b723a478be77bf74718947cdcdd75144d508aaa70f0a320036905df2a8"
+dependencies = [
+ "secp256k1-sys 0.7.0",
 ]
 
 [[package]]
@@ -2759,6 +2771,15 @@ name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8058e28ae464daf5ac14c5c0f78110b58616e796c4e4e28cfcca38fdb13d8f22"
 dependencies = [
  "cc",
 ]
@@ -3385,7 +3406,7 @@ dependencies = [
  "multiaddr",
  "once_cell",
  "rand",
- "secp256k1",
+ "secp256k1 0.24.2",
  "serde",
  "serde_json",
  "sscanf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ num-bigint = "0.4.3"
 num-traits = "0.2.15"
 lazy_static = "1.4.0"
 thiserror = "1.0.30"
+secp256k1 = "0.25.0"
+data-encoding = "2.3.3"
+url = "2.3.1"
 
 [[example]]
 name = "poi-crosschecker"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
+use url::Url;
 
 pub mod gossip_agent;
 pub mod graphql;
@@ -41,6 +42,11 @@ pub static NONCES: OnceCell<Arc<Mutex<NoncesMap>>> = OnceCell::new();
 /// ```
 pub fn app_name() -> Cow<'static, str> {
     Cow::from("graphcast")
+}
+
+/// Returns hardcoded DNS Url to a discoverable ENR tree that should be used to retrieve boot nodes
+pub fn discovery_url() -> Url {
+    Url::parse("enrtree://AMRFINDNF7XHQN2XBYCGYAYSQ3NV77RJIHLX6HJLA6ZAF365NRLMM@graphcast.testnodes.graphops.xyz").expect("Could not parse discovery url to ENR tree")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Description
Every time a node has been restarted without Secp256k1 private key, a random key pair for configuring the waku node and thus create an unique peer id. 
- Allow radio to utilize the operator private key with optional host and port so that a static node list can be kept across restarts.
- Implemented DNS peer discovery with a hardcoded URL and fallback to the default static node list - have not test the function with a functional DNS url that serves the ENRtree zone file.
- Fixed a minor bug on using env var `port` when constructing boot node multiaddr instead of a constant `60000`

### Issue link (if applicable)
Static node impl for #15 
