### PR TITLE
feat: peer discovery with consistent DNS enrtree url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /.fleet
 /examples/target
 boot_node_addr.conf
-.envrc
+test_tree_zone.txt
+txt_records.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,7 @@ rsb_derive = "0.5.1"
 name = "poi-crosschecker"
 path = "examples/poi-crosschecker/src/main.rs"
 crate-type = ["bin"]
+
+[[bin]]
+name = "rect"
+path = "src/records_to_tree.rs"

--- a/src/gossip_agent/mod.rs
+++ b/src/gossip_agent/mod.rs
@@ -183,8 +183,8 @@ impl GossipAgent {
             .provider
             .get_block(block_number)
             .await
-            .unwrap()
-            .unwrap();
+            .expect("Failed to query block from node provider based on block number")
+            .expect("Node Provider returned None for the queried block");
         let block_hash = format!("{:#x}", block.hash.unwrap());
         let content_topic = self.match_content_topic(identifier.clone())?;
 

--- a/src/gossip_agent/waku_handling.rs
+++ b/src/gossip_agent/waku_handling.rs
@@ -132,14 +132,16 @@ fn initialize_node_handle(
     let node_handle = waku_new(node_config).unwrap().start().unwrap();
     let all_nodes = match node_handle.dns_discovery(&discovery_url(), None, None) {
         Ok(x) => {
-            println!("Discovered multiaddresses: {:#?}", x);
+            println!("{} {:#?}", "Discovered multiaddresses:".green(), x);
             let mut discovered_nodes = x;
+            // Should static node be added or just use as fallback?
             discovered_nodes.extend(nodes.into_iter());
             discovered_nodes
         }
         Err(e) => {
             println!(
-                "Could not discover nodes with provided Url, only add static node list: {:?}",
+                "{}{:?}",
+                "Could not discover nodes with provided Url, only add static node list: ".yellow(),
                 e
             );
             nodes
@@ -167,9 +169,9 @@ fn connect_multiaddresses(
             let peer_id = node_handle
                 .add_peer(address, protocol_id)
                 .unwrap_or_else(|_| String::from("Could not add peer"));
-            node_handle
-                .connect_peer_with_id(peer_id.clone(), None)
-                .unwrap();
+            if let Err(e) = node_handle.connect_peer_with_id(peer_id.clone(), None) {
+                println!("Could not connect to peer with id: {}", e);
+            };
             peer_id
         })
         .collect::<Vec<String>>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,12 @@ pub fn app_name() -> Cow<'static, str> {
 
 /// Returns hardcoded DNS Url to a discoverable ENR tree that should be used to retrieve boot nodes
 pub fn discovery_url() -> Url {
-    Url::parse("enrtree://AMRFINDNF7XHQN2XBYCGYAYSQ3NV77RJIHLX6HJLA6ZAF365NRLMM@graphcast.testnodes.graphops.xyz").expect("Could not parse discovery url to ENR tree")
+    let enr_url = config_env_var("ENR_URL").unwrap_or_else(|_| {
+        "enrtree://AMRFINDNF7XHQN2XBYCGYAYSQ3NV77RJIHLX6HJLA6ZAF365NRLMM@testfleet.graphcast.xyz"
+            .to_string()
+    });
+
+    Url::parse(&enr_url).expect("Could not parse discovery url to ENR tree")
 }
 
 /// Attempt to read environmental variable

--- a/src/records_to_tree.rs
+++ b/src/records_to_tree.rs
@@ -1,0 +1,29 @@
+use serde_json::Value;
+use std::fs;
+use std::io::{BufWriter, Write};
+
+/// Convert TXT records from the tree_creator to standard ZONE file
+fn main() {
+    // Set up file
+    let json_file = fs::read_to_string("txt_records.json").expect("Unable to read file");
+    let json: Value = serde_json::from_str(&json_file).expect("Unable to parse JSON");
+    let output_file = fs::File::create("test_tree_zone.txt").expect("Unable to create file");
+    let mut output = BufWriter::new(output_file);
+
+    // Initialize with standard configs
+    writeln!(output, "$ORIGIN testfleet.graphcast.xyz.\n$TTL 86400\ngraphcast.xyz	3600	IN	SOA	graphcast.xyz root.graphcast.xyz 2042508586 7200 3600 86400 3600\ntestfleet.graphcast.xyz.	86400	IN	A	192.168.64.1\ngraphcast.xyz.	1	IN	CNAME	testfleet.graphcast.xyz.").expect("Failed to write default configs");
+    // Iterate over the result tree
+    for (key, value) in json
+        .as_object()
+        .unwrap()
+        .get("result")
+        .expect("Unable to get result from JSON file")
+        .as_object()
+        .unwrap()
+        .iter()
+    {
+        let record = format!("{}. IN TXT {}", key, value);
+        writeln!(output, "{}", record).expect("Unable to write to file");
+    }
+    println!("Finished converting, check test_tree_zone.txt");
+}


### PR DESCRIPTION
### Description

Utilize CLI [tool](https://github.com/status-im/nim-dnsdisc) `tree_creator` to generate a ENR record tree signed by a consistent key pair. 
Manually set up DNS records on Cloudflare under the domain `graphcast.xyz`, then provide the ENR tree url for peer discovery.

Configurable tree url with fallback default at `enrtree://AMRFINDNF7XHQN2XBYCGYAYSQ3NV77RJIHLX6HJLA6ZAF365NRLMM@graphcast.xyz`

### Issue link (if applicable)
Resolves #15 
-> later set up automated process for keeping the record tree updated
