### PR TITLE
feat: config for publishing on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,7 +1503,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "graphcast-sdk"
-version = "0.0.1"
+version = "0.0.1-alpha1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "graphcast-sdk"
-version = "0.0.1"
+version = "0.0.1-alpha1"
 edition = "2021"
 authors = ["GraphOps (axiomatic-aardvark, hopeyen)"]
 description="SDK to build Graphcast Radios"
 license="Apache-2.0"
 repository="https://github.com/graphops/graphcast-sdk"
-keywords=["graphprotocol", "gossip network", "sdk"]
+keywords=["graphprotocol", "gossip-network", "sdk", "p2p", "networking"]
 categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]


### PR DESCRIPTION
This change was necessary because:
- crates.io doesn't support spaces in tags
- the version should signal that we are still pre-MVP (MVP will be `0.0.1`)