### PR TITLE
Generic radio payload message typing

### DIFF
--- a/examples/ping-pong/src/types.rs
+++ b/examples/ping-pong/src/types.rs
@@ -1,0 +1,28 @@
+use ethers_contract::EthAbiType;
+use ethers_core::types::transaction::eip712::Eip712;
+use ethers_derive_eip712::*;
+use prost::Message;
+use serde::{Deserialize, Serialize};
+
+#[derive(Eip712, EthAbiType, Clone, Message, Serialize, Deserialize)]
+#[eip712(
+    name = "Graphcast Ping-Pong Radio",
+    version = "0",
+    chain_id = 1,
+    verifying_contract = "0xc944e90c64b2c07662a292be6244bdf05cda44a7"
+)]
+pub struct RadioPayloadMessage {
+    #[prost(string, tag = "1")]
+    pub identifier: String,
+    #[prost(string, tag = "2")]
+    pub content: String,
+}
+
+impl RadioPayloadMessage {
+    pub fn new(identifier: String, content: String) -> Self {
+        RadioPayloadMessage {
+            identifier,
+            content,
+        }
+    }
+}

--- a/src/records_to_tree.rs
+++ b/src/records_to_tree.rs
@@ -11,7 +11,7 @@ fn main() {
     let mut output = BufWriter::new(output_file);
 
     // Initialize with standard configs
-    writeln!(output, "$ORIGIN testfleet.graphcast.xyz.\n$TTL 86400\ngraphcast.xyz	3600	IN	SOA	graphcast.xyz root.graphcast.xyz 2042508586 7200 3600 86400 3600\ntestfleet.graphcast.xyz.	86400	IN	A	192.168.64.1\ngraphcast.xyz.	1	IN	CNAME	testfleet.graphcast.xyz.").expect("Failed to write default configs");
+    writeln!(output, "$ORIGIN testfleet.graphcast.xyz.\n$TTL 86400\ngraphcast.xyz	3600	IN	SOA	graphcast.xyz root.graphcast.xyz 2042508586 7200 3600 86400 3600\ntestfleet.graphcast.xyz.	86400	IN	A	165.227.156.72\ngraphcast.xyz.	1	IN	CNAME	testfleet.graphcast.xyz.").expect("Failed to write default configs");
     // Iterate over the result tree
     for (key, value) in json
         .as_object()


### PR DESCRIPTION
### Description
For different radio use cases, the structure of the radio payloads inside `GraphcastMessage` must be flexible. This PR allows Radio specific message definitions to be passed in as a generic protobuf `message` field in the `GraphcastMessage`. 

Individual radios are responsible for satisfying 
- [Eip712](https://eips.ethereum.org/EIPS/eip-712) standard for message hashing and signing and 
- [Protobuf](https://docs.rs/prost/latest/prost/index.html) types for encoding and decoding during transmission. 

Example Radio message definition
```
    /// Required packages
    use ethers_core::types::transaction::eip712::Eip712;
    use ethers_derive_eip712::*;
    use prost::Message;
    use serde::{Deserialize, Serialize};

    /// Auto trait derivations for radio message. Example  with 2 fields
    #[derive(Eip712, EthAbiType, Clone, Message, Serialize, Deserialize)]
    #[eip712(
        name = "Graphcast Test Radio",
        version = "0",
        chain_id = 1,
        verifying_contract = "0xc944e90c64b2c07662a292be6244bdf05cda44a7"
    )]
    pub struct RadioPayloadMessage {
        #[prost(string, tag = "1")]
        pub identifier: String,
        #[prost(string, tag = "2")]
        pub content: String,
    }

    /// Helper functions for construction and extractions, but not necessary since the fields are public
    impl RadioPayloadMessage {
        pub fn new(identifier: String, content: String) -> Self {
            RadioPayloadMessage {
                identifier,
                content,
            }
        }

        pub fn content_string(&self) -> String {
            self.content.clone()
        }
    }
```

### Issue link (if applicable)
Closes #18 
