### PR TITLE
fix: utilize cf nameserver, advertise multiaddress

### DIFF
--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -45,15 +45,19 @@ async fn main() {
     pub const NETWORK_SUBGRAPH: &str = "https://gateway.testnet.thegraph.com/network";
 
     let gossip_agent = GossipAgent::new(
+        // private_key resolves into ethereum wallet and indexer identity.
         private_key,
         eth_node,
+        // radio_name is used as part of the content topic for the radio application
         radio_name,
         REGISTRY_SUBGRAPH,
         NETWORK_SUBGRAPH,
-        // Content topics that the Radio subscribes to
-        // If we pass in `None` Graphcast will default to using the ipfs hashes of the subgraphs that the Indexer is allocating to.
-        // But in this case we will override it with something much more simple.
+        // subtopic optionally provided and used as the content topic identifier of the message subject,
+        // if not provided then they are generated based on indexer allocations
         Some(vec!["ping-pong-content-topic"]),
+        // Waku node address is set up by optionally providing a host and port, and an advertised address to be connected among the waku peers
+        // Advertised address can be any multiaddress that is self-describing and support addresses for any network protocol (tcp, udp, ip; tcp6, udp6, ip6 for IPv6)
+        None,
         None,
         None,
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use std::{
     env,
     sync::{Arc, Mutex},
 };
-use url::Url;
+use url::{Host, Url};
 
 pub mod gossip_agent;
 pub mod graphql;
@@ -54,6 +54,10 @@ pub fn discovery_url() -> Url {
     });
 
     Url::parse(&enr_url).expect("Could not parse discovery url to ENR tree")
+}
+
+pub fn cf_nameserver() -> Host {
+    Host::Domain("konnor.ns.cloudflare.com".to_string())
 }
 
 /// Attempt to read environmental variable

--- a/src/records_to_tree.rs
+++ b/src/records_to_tree.rs
@@ -11,7 +11,7 @@ fn main() {
     let mut output = BufWriter::new(output_file);
 
     // Initialize with standard configs
-    writeln!(output, "$ORIGIN testfleet.graphcast.xyz.\n$TTL 86400\ngraphcast.xyz	3600	IN	SOA	graphcast.xyz root.graphcast.xyz 2042508586 7200 3600 86400 3600\ntestfleet.graphcast.xyz.	86400	IN	A	192.168.64.1\ngraphcast.xyz.	1	IN	CNAME	testfleet.graphcast.xyz.").expect("Failed to write default configs");
+    writeln!(output, "$ORIGIN testfleet.graphcast.xyz.\n$TTL 86400\ngraphcast.xyz	3600	IN	SOA	graphcast.xyz root.graphcast.xyz 2042508586 7200 3600 86400 3600\ntestfleet.graphcast.xyz.	86400	IN	A	165.227.156.72\ngraphcast.xyz.	1	IN	CNAME	testfleet.graphcast.xyz.").expect("Failed to write default configs");
     // Iterate over the result tree
     for (key, value) in json
         .as_object()


### PR DESCRIPTION
### Description
- Utilize Cloudflare DNS nameserver for discovery
- Allow users to provide customized multiaddress to advertise to peers
- Update logs to be more accurate for connected peers
- Use exposed IP endpoint 

### Issue link (if applicable)
Closes #55 
