### PR TITLE
Refactor topics and Gossip agent

### DIFF
--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -57,6 +57,9 @@ async fn main() {
 
     /// A constant defining the goerli network subgraph endpoint.
     pub const NETWORK_SUBGRAPH: &str = "https://gateway.testnet.thegraph.com/network";
+    // subtopics are optionally provided and used as the content topic identifier of the message subject,
+    // if not provided then they are generated based on indexer allocations
+    let subtopics = vec!["ping-pong-content-topic".to_string()];
 
     let gossip_agent = GossipAgent::new(
         // private_key resolves into ethereum wallet and indexer identity.
@@ -64,11 +67,9 @@ async fn main() {
         eth_node,
         // radio_name is used as part of the content topic for the radio application
         radio_name,
+        Some(subtopics),
         REGISTRY_SUBGRAPH,
         NETWORK_SUBGRAPH,
-        // subtopic optionally provided and used as the content topic identifier of the message subject,
-        // if not provided then they are generated based on indexer allocations
-        Some(vec!["ping-pong-content-topic"]),
         // Waku node address is set up by optionally providing a host and port, and an advertised address to be connected among the waku peers
         // Advertised address can be any multiaddress that is self-describing and support addresses for any network protocol (tcp, udp, ip; tcp6, udp6, ip6 for IPv6)
         waku_host,
@@ -112,7 +113,7 @@ async fn main() {
                 MESSAGES.get().unwrap().lock().unwrap().push(msg);
             }
             Err(err) => {
-                println!("{}", err);
+                println!("{err}");
             }
         };
 

--- a/src/gossip_agent/message_typing.rs
+++ b/src/gossip_agent/message_typing.rs
@@ -209,7 +209,7 @@ impl<T: Message + ethers::types::transaction::eip712::Eip712 + Default + Clone +
                     .unwrap(),
             )
         }) {
-            Ok(addr) => Ok(format!("{:#x}", addr)),
+            Ok(addr) => Ok(format!("{addr:#x}")),
             Err(x) => Err(anyhow!(x)),
         }
     }

--- a/src/graphql/client_network.rs
+++ b/src/graphql/client_network.rs
@@ -45,8 +45,7 @@ pub async fn query_network_subgraph(
         data
     } else {
         return Err(QueryError::Other(anyhow::anyhow!(format!(
-            "Missing response data from network subgraph for {}",
-            indexer_address
+            "Missing response data from network subgraph for {indexer_address}"
         ))));
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 //! For more explanation, see the crate documentation.
 //!
 
+use ethers::signers::{Signer, Wallet};
+use ethers_core::k256::ecdsa::SigningKey;
 use once_cell::sync::OnceCell;
 use std::{
     borrow::Cow,
@@ -23,7 +25,7 @@ use std::{
     env,
     sync::{Arc, Mutex},
 };
-use tracing::Level;
+use tracing::{debug, Level};
 use tracing_subscriber::FmtSubscriber;
 use url::{Host, Url};
 
@@ -64,7 +66,12 @@ pub fn cf_nameserver() -> Host {
 
 /// Attempt to read environmental variable
 pub fn config_env_var(name: &str) -> Result<String, String> {
-    env::var(name).map_err(|e| format!("{}: {}", name, e))
+    env::var(name).map_err(|e| format!("{name}: {e}"))
+}
+
+pub fn operator_address(wallet: &Wallet<SigningKey>) -> String {
+    debug!("{}", format!("Wallet address: {:?}", wallet.address()));
+    format!("{:?}", wallet.address())
 }
 
 /// Sets up tracing, allows log level to be set from the environment variables
@@ -91,7 +98,7 @@ mod tests {
 
     #[test]
     fn test_build_content_topics() {
-        let basics = ["Qmyumyum", "Ymqumqum"].to_vec();
+        let basics = ["Qmyumyum".to_string(), "Ymqumqum".to_string()].to_vec();
         let res = build_content_topics("some-radio", 0, &basics);
         for i in 0..res.len() {
             assert_eq!(res[i].content_topic_name, basics[i]);

--- a/src/tree_to_txt.rs
+++ b/src/tree_to_txt.rs
@@ -22,8 +22,8 @@ fn main() {
         .unwrap()
         .iter()
     {
-        let record = format!("{}. IN TXT {}", key, value);
-        writeln!(output, "{}", record).expect("Unable to write to file");
+        let record = format!("{key}. IN TXT {value}");
+        writeln!(output, "{record}").expect("Unable to write to file");
     }
     println!("Finished converting, check test_tree_zone.txt");
 }


### PR DESCRIPTION
### Description
Refactor topic generations for more flexible usage for 3LA initialization - if no subtopic is provided, then no filtering for the messages. 
Reduce the size of Gossip agent to not keep track of indexer address and allocations. 

### Issue link (if applicable)
Closes #62
