### PR TITLE
Automatic reconnect to peers

### DIFF
--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -39,6 +39,8 @@ async fn main() {
     /// the handler itself is being passed into the Gossip Agent, so it needs to be static as well.
     pub static GOSSIP_AGENT: OnceCell<GossipAgent> = OnceCell::new();
 
+    let waku_host = env::var("WAKU_HOST").ok();
+    let waku_port = env::var("WAKU_PORT").ok();
     // The private key for you Graphcast operator address
     let private_key = env::var("PRIVATE_KEY").expect("No operator private key provided.");
 
@@ -69,8 +71,8 @@ async fn main() {
         Some(vec!["ping-pong-content-topic"]),
         // Waku node address is set up by optionally providing a host and port, and an advertised address to be connected among the waku peers
         // Advertised address can be any multiaddress that is self-describing and support addresses for any network protocol (tcp, udp, ip; tcp6, udp6, ip6 for IPv6)
-        None,
-        None,
+        waku_host,
+        waku_port,
         None,
     )
     .await

--- a/src/gossip_agent/mod.rs
+++ b/src/gossip_agent/mod.rs
@@ -27,7 +27,9 @@ use waku::{
 };
 
 use self::message_typing::GraphcastMessage;
-use self::waku_handling::{build_content_topics, handle_signal, pubsub_topic, setup_node_handle};
+use self::waku_handling::{
+    build_content_topics, handle_signal, network_check, pubsub_topic, setup_node_handle,
+};
 
 use crate::graphql::{
     client_network::query_network_subgraph, client_registry::query_registry_indexer,
@@ -259,6 +261,9 @@ impl GossipAgent {
                 .ok_or(AgentError::UnexpectedResponseError)?
         );
         let content_topic = self.match_content_topic(identifier.clone())?;
+
+        // Check network before sending a message
+        network_check(&self.node_handle)?;
 
         GraphcastMessage::build(
             &self.wallet,


### PR DESCRIPTION
### Description
Before sending a message, the gossip client checks for network connectivity with the established known peers, and attempts to reconnect if the peer has been disconnected. This will allow nodes to assume as normal without manual restart when service nodes are rebooted.

Further consideration is that client is doing more work per sending of message, so it could be a good idea to check connectivity less frequent, but also made sense to do so before sending a message since they are only connected to routing nodes so far.

### Issue link (if applicable)
Closes #60 
