### PR TITLE
feat: waku_node_key and waku_log_level

### DIFF
--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -41,6 +41,7 @@ async fn main() {
 
     let waku_host = env::var("WAKU_HOST").ok();
     let waku_port = env::var("WAKU_PORT").ok();
+    let waku_node_key = env::var("WAKU_NODE_KEY").ok();
     // The private key for you Graphcast operator address
     let private_key = env::var("PRIVATE_KEY").expect("No operator private key provided.");
 
@@ -75,6 +76,7 @@ async fn main() {
         Some(subtopics),
         // Waku node address is set up by optionally providing a host and port, and an advertised address to be connected among the waku peers
         // Advertised address can be any multiaddress that is self-describing and support addresses for any network protocol (tcp, udp, ip; tcp6, udp6, ip6 for IPv6)
+        waku_node_key,
         waku_host,
         waku_port,
         None,

--- a/src/gossip_agent/mod.rs
+++ b/src/gossip_agent/mod.rs
@@ -99,6 +99,7 @@ impl GossipAgent {
         network_subgraph: &str,
         boot_node_addresses: Vec<String>,
         subtopics: Option<Vec<String>>,
+        waku_node_key: Option<String>,
         waku_host: Option<String>,
         waku_port: Option<String>,
         waku_addr: Option<String>,
@@ -116,7 +117,7 @@ impl GossipAgent {
                 "Could not make format advertised address into a Multiaddress, do not advertise",
             )
         });
-        let node_key = waku::SecretKey::from_str(&private_key).ok();
+        let node_key = waku_node_key.and_then(|key| waku::SecretKey::from_str(&key).ok());
 
         let node_handle = setup_node_handle(
             boot_node_addresses,

--- a/src/gossip_agent/waku_handling.rs
+++ b/src/gossip_agent/waku_handling.rs
@@ -111,12 +111,14 @@ fn node_config(
     enable_relay: bool,
     enable_filter: bool,
 ) -> Option<WakuNodeConfig> {
-    let log_level = match env::var("LOG_LEVEL") {
+    let log_level = match env::var("WAKU_LOG_LEVEL") {
         Ok(level) => match level.to_uppercase().as_str() {
             "INFO" => WakuLogLevel::Info,
             "DEBUG" => WakuLogLevel::Debug,
             "WARN" => WakuLogLevel::Warn,
             "ERROR" => WakuLogLevel::Error,
+            "FATAL" => WakuLogLevel::Fatal,
+            "PANIC" => WakuLogLevel::Panic,
             _ => WakuLogLevel::Info,
         },
         Err(_) => WakuLogLevel::Info,


### PR DESCRIPTION
### Description
`waku_node_key` - Optional environmental variable as a parameter to initialize Graphcast agent, fallback with None which allows node key to be generated upon initializing the waku node.
`waku_log_level` - Optional environmental variable with `INFO` log level as fallback

### Issue link (if applicable)
Closes #77
