### PR TITLE
feat: bump waku binding with filter and relay topic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3171,6 +3171,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smart-default"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3770,8 +3781,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "waku-bindings"
-version = "0.1.0-beta1"
-source = "git+https://github.com/waku-org/waku-rust-bindings?rev=0fb4e2e#0fb4e2e917629143608654cb3762efb78bff8ca2"
+version = "0.1.0-beta3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0791fe403f961553a569de59cbec51589d9c215d0ed2b226edb91ece19904c6"
 dependencies = [
  "aes-gcm",
  "base64 0.13.1",
@@ -3782,6 +3794,7 @@ dependencies = [
  "secp256k1 0.24.3",
  "serde",
  "serde_json",
+ "smart-default",
  "sscanf",
  "url",
  "waku-sys",
@@ -3789,8 +3802,9 @@ dependencies = [
 
 [[package]]
 name = "waku-sys"
-version = "0.1.0-beta1"
-source = "git+https://github.com/waku-org/waku-rust-bindings?rev=0fb4e2e#0fb4e2e917629143608654cb3762efb78bff8ca2"
+version = "0.1.0-beta3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b99fe445a5a97b22eed035b104dbe547fdc6b29035e2b3a02846d52d77be8e3"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords=["graphprotocol", "gossip network", "sdk"]
 categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
-waku = { package = "waku-bindings", git = "https://github.com/waku-org/waku-rust-bindings", rev="0fb4e2e" }
+waku = { package = "waku-bindings", version="0.1.0-beta3" }
 slack-morphism = { version = "1.5", features = ["hyper", "axum"] }
 prost = "0.11"
 once_cell = "1.15"


### PR DESCRIPTION
### Description
- Update protocol connection mechanism to use Filter protocol
- Utilizes Filter subscription and removed custom content topic check
- Add pubsub topic in waku node initiation as `relay_topics`
- Minor refactoring of related logs
- Added fields for `Discv5` but not utilized yet

Testing needed before merge
### Issue link (if applicable)
Resolves #49 
