### PR TITLE
refactor: rename agent to graphcast

### DIFF
--- a/src/graphcast_agent/message_typing.rs
+++ b/src/graphcast_agent/message_typing.rs
@@ -204,7 +204,7 @@ impl<T: Message + ethers::types::transaction::eip712::Eip712 + Default + Clone +
 
     /// Check timestamp: prevent past message replay
     pub fn valid_time(&self) -> Result<&Self, anyhow::Error> {
-        //Can store for measuring overall gossip message latency
+        //Can store for measuring overall Graphcast message latency
         let message_age = Utc::now().timestamp() - self.nonce;
         // 0 allow instant atomic messaging, use 1 to exclude them
         if (0..MSG_REPLAY_LIMIT).contains(&message_age) {

--- a/src/graphcast_agent/waku_handling.rs
+++ b/src/graphcast_agent/waku_handling.rs
@@ -1,8 +1,8 @@
 use crate::{
     app_name, cf_nameserver, discovery_url,
-    gossip_agent::{
+    graphcast_agent::{
         message_typing::{self, GraphcastMessage},
-        GossipAgentError,
+        GraphcastAgentError,
     },
     NoncesMap,
 };
@@ -313,9 +313,9 @@ pub async fn handle_signal<
                         provider
                             .get_block(graphcast_message.block_number)
                             .await?
-                            .ok_or(GossipAgentError::EmptyResponseError)?
+                            .ok_or(GraphcastAgentError::EmptyResponseError)?
                             .hash
-                            .ok_or(GossipAgentError::UnexpectedResponseError)?
+                            .ok_or(GraphcastAgentError::UnexpectedResponseError)?
                     );
                     match check_message_validity(
                         graphcast_message,
@@ -350,7 +350,7 @@ pub async fn handle_signal<
 }
 
 /// Check validity of the message:
-/// Sender check verifies sender's on-chain identity with gossip registry
+/// Sender check verifies sender's on-chain identity with Graphcast registry
 /// Time check verifies that message was from within the acceptable timestamp
 /// Block hash check verifies sender's access to valid Ethereum node provider and blocks
 /// Nonce check ensures the ordering of the messages and avoids past messages

--- a/src/graphql/client_registry.rs
+++ b/src/graphql/client_registry.rs
@@ -11,7 +11,7 @@ use serde_derive::{Deserialize, Serialize};
 )]
 pub struct GraphAccount;
 
-/// Query registry subgraph endpoint for resolving gossip operator and indexer address
+/// Query registry subgraph endpoint for resolving Graphcast ID and indexer address
 pub async fn perform_operator_indexer_query(
     registry_subgraph_endpoint: String,
     variables: graph_account::Variables,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Graphcast
 //!
-//! `graphcast` is a development kit to build The Graph network
+//! `graphcast-sdk` is a development kit to build The Graph network
 //! gossip p2p messaging apps on top of the Waku Relay network.
 //!
 //! This library is a work in progress, in particular
@@ -29,7 +29,7 @@ use tracing::{debug, subscriber::SetGlobalDefaultError, Level};
 use tracing_subscriber::FmtSubscriber;
 use url::{Host, Url};
 
-pub mod gossip_agent;
+pub mod graphcast_agent;
 pub mod graphql;
 pub mod slack_bot;
 
@@ -120,7 +120,7 @@ pub fn init_tracing() -> Result<(), SetGlobalDefaultError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::gossip_agent::waku_handling::build_content_topics;
+    use crate::graphcast_agent::waku_handling::build_content_topics;
 
     #[test]
     fn test_build_content_topics() {


### PR DESCRIPTION
### Description
Rename relevant variable names to use `Graphcast` instead of `Gossip`

### Issue link (if applicable)
Resolves #79 
