### PR TITLE
content topic poll and update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,9 +165,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
+checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
 dependencies = [
  "glob",
  "libc",
@@ -905,6 +905,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enr"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492a7e5fc2504d5fdce8e124d3e263b244a68b283cac67a69eda0cd43e0aebad"
+dependencies = [
+ "base64 0.13.1",
+ "bs58",
+ "bytes",
+ "hex",
+ "k256",
+ "log",
+ "rand",
+ "rlp",
+ "secp256k1 0.24.3",
+ "serde",
+ "sha3",
+ "zeroize",
 ]
 
 [[package]]
@@ -1629,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -1980,9 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aebdb21e90f81d13ed01dc84123320838e53963c2ca94b60b305d3fa64f31e"
+checksum = "3b53e0cc5907a5c216ba6584bf74be8ab47d6d6289f72793b2dddbf15dc3bf8c"
 dependencies = [
  "arrayref",
  "byteorder",
@@ -2009,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
+checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
 dependencies = [
  "core2",
  "multihash-derive",
@@ -2861,9 +2881,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
 dependencies = [
- "rand",
  "secp256k1-sys 0.6.1",
- "serde",
 ]
 
 [[package]]
@@ -2872,7 +2890,9 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
+ "rand",
  "secp256k1-sys 0.8.0",
+ "serde",
 ]
 
 [[package]]
@@ -3119,18 +3139,18 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "slack-morphism"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89529265e8ce68446ec28a047cffec81032a12e95af4dab9a1b581665e23375a"
+checksum = "e3e4a477b28530f913f1f5196b5da4af100f2f212dd0275dd14b8f92cb82b2c9"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -3209,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "sscanf"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecdd7ea17bcadebf81d656db919f58f96c1d194d748cf0839a44a220123eedd"
+checksum = "887a5b09bbf30cc01d059ccb4b7a0b508a0cef3028df2f2ee0d745bc9e624c56"
 dependencies = [
  "const_format",
  "lazy_static",
@@ -3221,14 +3241,16 @@ dependencies = [
 
 [[package]]
 name = "sscanf_macro"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2309d255caf220c1ff9f380d89420a1377de1cabc1d57e0b308e53b0406bed"
+checksum = "b124cd4c68600cc3188a26987b1c3bed8cadcfd1be93124026096c668f2c0ee8"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
+ "strsim",
  "syn",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3449,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3782,17 +3804,17 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "waku-bindings"
-version = "0.1.0-beta4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "937ad768d4d294af5cc2f61264ae82d5ffbcf2687a8673bdc0a642410111bfea"
+version = "0.1.0-beta.5"
+source = "git+https://github.com/waku-org/waku-rust-bindings?branch=fix-nil-enr#2c4653e1a9458c307e148f5f05128fcd7796b656"
 dependencies = [
  "aes-gcm",
- "base64 0.13.1",
+ "base64 0.21.0",
+ "enr",
  "hex",
  "multiaddr",
  "once_cell",
  "rand",
- "secp256k1 0.24.3",
+ "secp256k1 0.26.0",
  "serde",
  "serde_json",
  "smart-default",
@@ -3803,9 +3825,8 @@ dependencies = [
 
 [[package]]
 name = "waku-sys"
-version = "0.1.0-beta4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c7db78c5dd30a60db499307a7d2992aeef35d6597311a89aa3c071189a70a6"
+version = "0.1.0-beta.5"
+source = "git+https://github.com/waku-org/waku-rust-bindings?branch=fix-nil-enr#2c4653e1a9458c307e148f5f05128fcd7796b656"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords=["graphprotocol", "gossip-network", "sdk", "waku", "p2p"]
 categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
-waku = { package = "waku-bindings", version="0.1.0-beta4" }
+waku = { package = "waku-bindings", git="https://github.com/waku-org/waku-rust-bindings", branch = "fix-nil-enr" }
 slack-morphism = { version = "1.5", features = ["hyper", "axum"] }
 prost = "0.11"
 once_cell = "1.15"

--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -86,7 +86,7 @@ async fn main() {
         &graph_node_endpoint,
         boot_node_addresses,
         Some(&graphcast_network),
-        Some(subtopics),
+        subtopics,
         // Waku node address is set up by optionally providing a host and port, and an advertised address to be connected among the waku peers
         // Advertised address can be any multiaddress that is self-describing and support addresses for any network protocol (tcp, udp, ip; tcp6, udp6, ip6 for IPv6)
         waku_node_key,

--- a/src/graphcast_agent/message_typing.rs
+++ b/src/graphcast_agent/message_typing.rs
@@ -143,17 +143,13 @@ impl<T: Message + ethers::types::transaction::eip712::Eip712 + Default + Clone +
         &self,
         node_handle: &WakuNodeHandle<Running>,
         pubsub_topic: WakuPubSubTopic,
-        content_topic: &WakuContentTopic,
+        content_topic: WakuContentTopic,
     ) -> Result<String, anyhow::Error> {
         let mut buff = Vec::new();
         Message::encode(self, &mut buff).expect("Could not encode :(");
 
-        let waku_message = WakuMessage::new(
-            buff,
-            content_topic.clone(),
-            2,
-            Utc::now().timestamp() as usize,
-        );
+        let waku_message =
+            WakuMessage::new(buff, content_topic, 2, Utc::now().timestamp() as usize);
 
         let sent_result = node_handle
             .peers()

--- a/src/graphcast_agent/waku_handling.rs
+++ b/src/graphcast_agent/waku_handling.rs
@@ -11,9 +11,9 @@ use std::{sync::Mutex, time::Duration};
 use tracing::{debug, error, info, warn};
 use url::ParseError;
 use waku::{
-    waku_new, ContentFilter, Encoding, FilterSubscription, Multiaddr, ProtocolId, Running,
-    SecretKey, Signal, WakuContentTopic, WakuLogLevel, WakuNodeConfig, WakuNodeHandle,
-    WakuPeerData, WakuPubSubTopic,
+    waku_dns_discovery, waku_new, ContentFilter, Encoding, FilterSubscription, Multiaddr,
+    ProtocolId, Running, SecretKey, Signal, WakuContentTopic, WakuLogLevel, WakuNodeConfig,
+    WakuNodeHandle, WakuPeerData, WakuPubSubTopic,
 };
 
 pub const SDK_VERSION: &str = "0";
@@ -179,11 +179,11 @@ pub fn connect_nodes(
     node_handle: &WakuNodeHandle<Running>,
     nodes: Vec<Multiaddr>,
 ) -> Result<(), WakuHandlingError> {
-    let all_nodes = match node_handle.dns_discovery(&discovery_url()?, Some(&cf_nameserver()), None)
-    {
-        Ok(x) => {
-            info!("{} {:#?}", "Discovered multiaddresses:".green(), x);
-            let mut discovered_nodes = x;
+    let all_nodes = match waku_dns_discovery(&discovery_url()?, Some(&cf_nameserver()), None) {
+        Ok(a) => {
+            info!("{} {:#?}", "Discovered multiaddresses:".green(), a);
+            let mut discovered_nodes: Vec<Multiaddr> =
+                a.iter().flat_map(|d| d.addresses.iter()).cloned().collect();
             // Should static node be added or just use as fallback?
             discovered_nodes.extend(nodes.into_iter());
             discovered_nodes

--- a/src/graphcast_agent/waku_handling.rs
+++ b/src/graphcast_agent/waku_handling.rs
@@ -107,6 +107,28 @@ pub fn filter_peer_subscriptions(
     Ok(filter_subscribe_result)
 }
 
+/// Make filter subscription requests to all peers except for ourselves
+/// Return subscription results for each peer
+pub fn unsubscribe_peer(
+    node_handle: &WakuNodeHandle<Running>,
+    graphcast_topic: &WakuPubSubTopic,
+    content_topics: &[WakuContentTopic],
+) -> Result<(), WakuHandlingError> {
+    let subscription: FilterSubscription =
+        content_filter_subscription(graphcast_topic, content_topics);
+    info!(
+        "Unsubscribe content topics on filter protocol: {:#?}",
+        subscription
+    );
+    node_handle
+        .filter_unsubscribe(&subscription, Duration::new(6000, 0))
+        .map_err(|e| {
+            WakuHandlingError::CannotUnsubscribe(format!(
+                "Waku node cannot unsubscribe to the topics: {e}"
+            ))
+        })
+}
+
 /// For boot nodes, configure a Waku Relay Node with filter protocol enabled (Waiting on filterFullNode waku-bindings impl). These node route all messages on the subscribed pubsub topic
 /// Preferrably also provide advertise_addr and Secp256k1 private key in Hex format (0x123...abc).
 ///
@@ -401,6 +423,8 @@ pub enum WakuHandlingError {
     ParseUrlError(#[from] ParseError),
     #[error("Unable to subscribe to pubsub topic. {}", .0)]
     CannotSubscribe(String),
+    #[error("Unable to unsubscribe to pubsub topic. {}", .0)]
+    CannotUnsubscribe(String),
     #[error("Unable to retrieve peers list. {}", .0)]
     UnableToRetrievePeers(String),
     #[error(transparent)]


### PR DESCRIPTION
### Description
Added a function to add new content topics to the filter protocol subscriptions.
- To make better update process such as to unsubscribe old topics, we need to make graphcast object mutable, which then require many operations to be unsafe
- We can later discuss how should the older topics be removed, if it should be some period after the indexer/operator has moved away from a particular Graph entity such as closing an allocation

I wanted to make a curried function similar to register signal handler, but want to first leave more control for individual radio to make periodic calls for updates as well as the query function structure

### Issue link (if applicable)
Partially resolves graphops/poi-radio#32
