### PR TITLE
refactor: log filters and new error variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,6 +1963,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
+checksum = "3933d3ac2717077b3d5f42b40f59edfb1fb6a8c14e1c7de0f38075c4bac8e314"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2484,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
+checksum = "8e9935362e8369bc3acd874caeeae814295c504c2bdbcde5c024089cf8b4dc12"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2563,6 +2572,15 @@ checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -3295,9 +3313,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "d56e159d99e6c2b93995d171050271edb50ecc5288fbc7cc17de8fdce4e58c14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3627,10 +3645,14 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ url = "2.3.1"
 rsb_derive = "0.5.1"
 dotenv = "0.15.0"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi", "fmt", "std"]}
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -4,7 +4,9 @@ use ethers::{
     types::U64,
 };
 use graphcast_sdk::{
-    graphcast_agent::{message_typing::GraphcastMessage, GraphcastAgent},
+    graphcast_agent::{
+        message_typing::GraphcastMessage, waku_handling::WakuHandlingError, GraphcastAgent,
+    },
     init_tracing, read_boot_node_addresses, NetworkName,
 };
 use once_cell::sync::OnceCell;
@@ -131,7 +133,7 @@ async fn main() {
     // There cannot be any non-deterministic (this includes async) code inside the handler.
     // That is why we're saving the message for later processing, where we will check its content and perform some action based on it.
     let radio_handler =
-        |msg: Result<GraphcastMessage<RadioPayloadMessage>, anyhow::Error>| match msg {
+        |msg: Result<GraphcastMessage<RadioPayloadMessage>, WakuHandlingError>| match msg {
             Ok(msg) => {
                 MESSAGES
                     .get()
@@ -141,7 +143,7 @@ async fn main() {
                     .push(msg);
             }
             Err(err) => {
-                println!("{err}");
+                error!("{err}");
             }
         };
 

--- a/src/graphql/client_network.rs
+++ b/src/graphql/client_network.rs
@@ -43,9 +43,9 @@ pub async fn query_network_subgraph(
     let data = if let Some(data) = response_body.data {
         data
     } else {
-        return Err(QueryError::Other(anyhow::anyhow!(format!(
+        return Err(QueryError::EmptyResponseError(format!(
             "Missing response data from network subgraph for {indexer_address}"
-        ))));
+        )));
     };
 
     let indexer =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,8 @@ use std::{
     env,
     sync::{Arc, Mutex},
 };
-use tracing::{debug, subscriber::SetGlobalDefaultError, Level};
+use tracing::{debug, subscriber::SetGlobalDefaultError};
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::FmtSubscriber;
 use url::{Host, Url};
 use waku::WakuPubSubTopic;
@@ -230,19 +231,18 @@ pub static NETWORKS: Lazy<Vec<Network>> = Lazy::new(|| {
 
 /// Sets up tracing, allows log level to be set from the environment variables
 pub fn init_tracing() -> Result<(), SetGlobalDefaultError> {
-    let log_level = match env::var("LOG_LEVEL") {
-        Ok(level) => match level.to_uppercase().as_str() {
-            "INFO" => Level::INFO,
-            "DEBUG" => Level::DEBUG,
-            "TRACE" => Level::TRACE,
-            "WARN" => Level::WARN,
-            "ERROR" => Level::ERROR,
-            _ => Level::INFO,
-        },
-        Err(_) => Level::INFO,
-    };
+    let filter = EnvFilter::from_default_env();
+    // let level_filter = filter.max_level_hint().unwrap_or(Level::ERROR.into());
 
-    let subscriber = FmtSubscriber::builder().with_max_level(log_level).finish();
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(filter)
+        // .with_max_level(level_filter)
+        .with_ansi(true)
+        .with_target(true)
+        .with_level(true)
+        .with_line_number(true)
+        .pretty()
+        .finish();
     tracing::subscriber::set_global_default(subscriber)
 }
 


### PR DESCRIPTION
### Description
Added `EnvFilter` logs configuring log levels, added error variants to replace mostly all of the anyhow errors

Example usage: `RUST_LOG="off,hyper=off,graphcast_sdk=debug,ping_pong=debug"`

This doesn't include waku logs but should be fixed soon.

### Issue link (if applicable)
graphops/poi-radio#10
