### PR TITLE
basic args validation and improve logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,17 +598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,7 +1522,6 @@ dependencies = [
  "cargo-husky",
  "chrono",
  "clap",
- "colored",
  "data-encoding",
  "dotenv",
  "ethers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
 waku = { package = "waku-bindings", version= "0.1.0-rc.2" }
-slack-morphism = { version = "1.5", features = ["hyper", "axum"] }
+slack-morphism = { version = "1.8", features = ["hyper", "axum"] }
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"
-serde = "1.0.147"
+serde = "1.0.155"
 serde_json = "1.0.93"
 tokio = {version = "1.1.1", features = ["full"]}
 anyhow = "1.0.69"
@@ -27,7 +27,6 @@ ethers-contract = "2.0.0"
 ethers-core = "2.0.0"
 ethers-derive-eip712 = "2.0.0"
 clap = { version = "3.2.23", features = ["derive", "env"] }
-colored = "2.0.0"
 toml = "0.5.7"
 partial_application = "0.2.1"
 prometheus-http-query = "0.6.5"

--- a/src/graphql/client_network.rs
+++ b/src/graphql/client_network.rs
@@ -95,6 +95,7 @@ pub struct Network {
 impl Network {
     /// Fetch indexer staked tokens
     pub fn indexer_stake(&self) -> BigUint {
+        // TODO: do division by 1e18 for grt unit
         self.indexer
             .as_ref()
             .map(|i| i.staked_tokens.clone())

--- a/src/graphql/client_registry.rs
+++ b/src/graphql/client_registry.rs
@@ -1,6 +1,6 @@
 use graphql_client::{GraphQLQuery, Response};
 use serde_derive::{Deserialize, Serialize};
-use tracing::debug;
+use tracing::warn;
 
 use super::QueryError;
 
@@ -39,7 +39,7 @@ pub async fn query_registry_indexer(
     let queried_result =
         perform_graphcast_id_indexer_query(registry_subgraph_endpoint, variables).await?;
     if !&queried_result.status().is_success() {
-        debug!("Unsuccessful query detail: {:#?}", queried_result);
+        warn!("Unsuccessful query detail: {:#?}", queried_result);
     }
     let response_body: Response<indexers::ResponseData> = queried_result.json().await?;
     if let Some(data) = response_body.data {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,35 +78,10 @@ pub fn config_env_var(name: &str) -> Result<String, String> {
     env::var(name).map_err(|e| format!("{name}: {e}"))
 }
 
-/// Get the graphcastID addresss associated with a given Indexer address
+/// Get the graphcastID address from the wallet
 pub fn graphcast_id_address(wallet: &Wallet<SigningKey>) -> String {
     debug!("{}", format!("Wallet address: {:?}", wallet.address()));
     format!("{:?}", wallet.address())
-}
-
-/// Helper function to parse boot node addresses from the environment variables
-/// Defaults to an empty vec if it cannot find the 'BOOT_NODE_ADDRESSES' environment variable
-/// Multiple formats for defining the addresses list are supported, such as:
-/// 1. BOOT_NODE_ADDRESSES=[addr1, addr2, addr3]
-/// 2. BOOT_NODE_ADDRESSES="addr1", "addr2", "addr3"
-/// 3. BOOT_NODE_ADDRESSES="addr1, addr2, addr3"
-/// 4. BOOT_NODE_ADDRESSES=addr1, addr2, addr3
-/// 5. BOOT_NODE_ADDRESSES=addr
-/// 6. BOOT_NODE_ADDRESSES="[addr1, addr2, addr3]"
-// TODO: Simplify according to the clap parser
-pub fn read_boot_node_addresses(boot_addresses: String) -> Vec<String> {
-    let mut addresses = Vec::new();
-    for address in boot_addresses.split(',') {
-        let address = address.trim();
-        if address.is_empty() {
-            continue;
-        } else if address.starts_with('"') && address.ends_with('"') {
-            addresses.push(address[1..address.len() - 1].to_string());
-        } else {
-            addresses.push(address.to_string());
-        }
-    }
-    addresses
 }
 
 /// Sets up tracing, allows log level to be set from the environment variables
@@ -159,21 +134,24 @@ pub fn determine_message_block(
     network_name: NetworkName,
 ) -> Result<u64, NetworkBlockError> {
     // Get the pre-configured examination frequency of the network
-    let examination_frequency = NETWORKS
+    let examination_frequency = match NETWORKS
         .iter()
-        .find(|n| n.name.to_string() == network_name.to_string()).map(|n| n.interval)
-        .ok_or({
+        .find(|n| n.name.to_string() == network_name.to_string())
+    {
+        Some(n) => n.interval,
+        None => {
             let err_msg = format!("Subgraph is indexing an unsupported network {network_name}, please report an issue on https://github.com/graphops/graphcast-rs");
             warn!(err_msg);
-            NetworkBlockError::UnsupportedNetwork(err_msg)
-        })?;
+            return Err(NetworkBlockError::UnsupportedNetwork(err_msg));
+        }
+    };
 
     // Calculate the relevant block for the message
     match network_chainhead_blocks.get(&network_name) {
         Some(BlockPointer { hash: _, number }) => Ok(number - number % examination_frequency),
         None => {
             let err_msg = format!(
-                "Could not get the chainhead block number on network {network_name} for determining the message's relevant block",
+                "Could not get the chainhead block number on network {network_name} for determining the message's relevant block, check if graph node has a deployment indexing the network",
             );
             warn!(err_msg);
             Err(NetworkBlockError::FailedStatus(err_msg))
@@ -217,7 +195,6 @@ pub enum NetworkBlockError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::graphcast_agent::waku_handling::build_content_topics;
 
     #[test]
@@ -228,53 +205,5 @@ mod tests {
             assert_eq!(res[i].content_topic_name, basics[i]);
             assert_eq!(res[i].application_name, "some-radio");
         }
-    }
-
-    #[test]
-    fn test_read_boot_node_addresses_empty() {
-        let items = read_boot_node_addresses(String::from(""));
-        assert_eq!(items, Vec::<String>::new());
-    }
-
-    #[test]
-    fn test_read_boot_node_addresses_no_quotes() {
-        let addresses = String::from("addr1, addr2, addr3");
-        let items = read_boot_node_addresses(addresses);
-        assert_eq!(items, vec!["addr1", "addr2", "addr3"]);
-    }
-
-    #[test]
-    fn test_read_boot_node_addresses_single_item_no_quotes() {
-        let addresses = String::from("addr1");
-        let items = read_boot_node_addresses(addresses);
-        assert_eq!(items, vec!["addr1"]);
-    }
-
-    #[test]
-    fn test_read_boot_node_addresses_single_item_with_quotes() {
-        let addresses = String::from("addr1");
-        let items = read_boot_node_addresses(addresses);
-        assert_eq!(items, vec!["addr1"]);
-    }
-
-    #[test]
-    fn test_read_boot_node_addresses_with_quotes() {
-        let addresses = String::from(r#""addr1", "addr2", "addr3""#);
-        let items = read_boot_node_addresses(addresses);
-        assert_eq!(items, vec!["addr1", "addr2", "addr3"]);
-    }
-
-    #[test]
-    fn test_read_boot_node_addresses_with_commas_no_quotes() {
-        let addresses = String::from("addr1,addr2,addr3");
-        let items = read_boot_node_addresses(addresses);
-        assert_eq!(items, vec!["addr1", "addr2", "addr3"]);
-    }
-
-    #[test]
-    fn test_read_boot_node_addresses_with_commas_and_quotes() {
-        let addresses = String::from(r#""addr1","addr2","addr3""#);
-        let items = read_boot_node_addresses(addresses);
-        assert_eq!(items, vec!["addr1", "addr2", "addr3"]);
     }
 }


### PR DESCRIPTION
### Description
Added validations to a couple of the start-up configurations

- graph_node_endpoint - by an indexing statuses query
- private_key - by parsing to an Ethereum wallet
- registry_subgraph - by indexer id query
- network_subgraph - by indexer_stake query
- graphcast_network - limited to mainnet or testnet, can be relaxed later
- collect_message_duration - minimum set to 0
- boot_node_addresses - by parsing to MultiAddr
- log_level - by setting up the logger

Skipping
- topics - no validation needed
- waku_host, waku_port, waku_node_key, waku_log_level - Waku input get validated when creating Graphcast agent

Later add validation to optional arguments if they were provided
- metrics_url
- slack_token
- slack_webhook

Improved SDK logs to 
- Remove info logs on "Message Received" and "Sent message id"
- changed hierarchy of many smaller info and debug logs

### Issue link (if applicable)
Helps with graphops/poi-radio#53
