### PR TITLE
feat: mnemonics allowed, refactor network config

### DIFF
--- a/src/graphcast_agent/message_typing.rs
+++ b/src/graphcast_agent/message_typing.rs
@@ -13,12 +13,12 @@ use tracing::debug;
 use waku::{Running, WakuContentTopic, WakuMessage, WakuNodeHandle, WakuPeerData, WakuPubSubTopic};
 
 use crate::{
-    config::NetworkName,
     graphql::{
         client_graph_node::query_graph_node_network_block_hash,
         client_network::query_network_subgraph, client_registry::query_registry_indexer,
         QueryError,
     },
+    networks::NetworkName,
     NoncesMap,
 };
 

--- a/src/graphcast_agent/mod.rs
+++ b/src/graphcast_agent/mod.rs
@@ -30,12 +30,12 @@ use self::waku_handling::{
     setup_node_handle, WakuHandlingError,
 };
 
-use crate::config::NetworkName;
 use crate::graphcast_agent::waku_handling::unsubscribe_peer;
 use crate::graphql::client_graph_node::query_graph_node_network_block_hash;
 use crate::graphql::client_registry::query_registry_indexer;
 use crate::graphql::QueryError;
-use crate::{graphcast_id_address, NoncesMap};
+use crate::networks::NetworkName;
+use crate::{build_wallet, graphcast_id_address, NoncesMap};
 
 pub mod message_typing;
 pub mod waku_handling;
@@ -105,7 +105,7 @@ impl GraphcastAgent {
     /// ```
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
-        private_key: String,
+        wallet_key: String,
         radio_name: &'static str,
         registry_subgraph: &str,
         network_subgraph: &str,
@@ -118,7 +118,7 @@ impl GraphcastAgent {
         waku_port: Option<String>,
         waku_addr: Option<String>,
     ) -> Result<GraphcastAgent, GraphcastAgentError> {
-        let wallet = private_key.parse::<LocalWallet>()?;
+        let wallet = build_wallet(&wallet_key)?;
         let pubsub_topic: WakuPubSubTopic = pubsub_topic(graphcast_namespace);
 
         //Should we allow the setting of waku node host and port?

--- a/src/graphql/client_graph_node.rs
+++ b/src/graphql/client_graph_node.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::graphql::QueryError;
 use crate::NetworkPointer;
-use crate::{config::NetworkName, BlockPointer};
+use crate::{networks::NetworkName, BlockPointer};
 use graphql_client::{GraphQLQuery, Response};
 use serde_derive::{Deserialize, Serialize};
 use tracing::{debug, trace, warn};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,12 @@
 //! For more explanation, see the crate documentation.
 //!
 
-use config::{NetworkName, NETWORKS};
-use ethers::signers::{Signer, Wallet};
+use ethers::signers::{
+    coins_bip39::English, LocalWallet, MnemonicBuilder, Signer, Wallet, WalletError,
+};
 use ethers_core::k256::ecdsa::SigningKey;
 use graphcast_agent::message_typing::GraphcastMessage;
+use networks::{NetworkName, NETWORKS};
 
 use once_cell::sync::OnceCell;
 use prost::Message;
@@ -42,6 +44,7 @@ pub mod bots;
 pub mod config;
 pub mod graphcast_agent;
 pub mod graphql;
+pub mod networks;
 
 type NoncesMap = HashMap<String, HashMap<String, i64>>;
 
@@ -76,6 +79,13 @@ pub fn cf_nameserver() -> Host {
 /// Attempt to read environmental variable
 pub fn config_env_var(name: &str) -> Result<String, String> {
     env::var(name).map_err(|e| format!("{name}: {e}"))
+}
+
+/// Build Wallet from Private key or Mnemonic
+pub fn build_wallet(value: &str) -> Result<Wallet<SigningKey>, WalletError> {
+    value
+        .parse::<LocalWallet>()
+        .or(MnemonicBuilder::<English>::default().phrase(value).build())
 }
 
 /// Get the graphcastID address from the wallet

--- a/src/networks.rs
+++ b/src/networks.rs
@@ -1,0 +1,128 @@
+use once_cell::sync::Lazy;
+use std::fmt;
+
+/// Struct for Network and block interval for updates
+#[derive(Debug, Clone)]
+pub struct Network {
+    pub name: NetworkName,
+    pub interval: u64,
+}
+
+/// List of supported networks
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum NetworkName {
+    Goerli,
+    Mainnet,
+    Gnosis,
+    Hardhat,
+    ArbitrumOne,
+    ArbitrumGoerli,
+    Avalanche,
+    Polygon,
+    Celo,
+    Optimism,
+    Fantom,
+    Unknown,
+}
+
+impl NetworkName {
+    pub fn from_string(name: &str) -> Self {
+        match name {
+            "goerli" => NetworkName::Goerli,
+            "mainnet" => NetworkName::Mainnet,
+            "gnosis" => NetworkName::Gnosis,
+            "hardhat" => NetworkName::Hardhat,
+            "arbitrum-one" => NetworkName::ArbitrumOne,
+            "arbitrum-goerli" => NetworkName::ArbitrumGoerli,
+            "avalanche" => NetworkName::Avalanche,
+            "polygon" => NetworkName::Polygon,
+            "celo" => NetworkName::Celo,
+            "optimism" => NetworkName::Optimism,
+            "fantom" => NetworkName::Fantom,
+            _ => NetworkName::Unknown,
+        }
+    }
+}
+
+impl fmt::Display for NetworkName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            NetworkName::Goerli => "goerli",
+            NetworkName::Mainnet => "mainnet",
+            NetworkName::Gnosis => "gnosis",
+            NetworkName::Hardhat => "hardhat",
+            NetworkName::ArbitrumOne => "arbitrum-one",
+            NetworkName::ArbitrumGoerli => "arbitrum-goerli",
+            NetworkName::Avalanche => "avalanche",
+            NetworkName::Polygon => "polygon",
+            NetworkName::Celo => "celo",
+            NetworkName::Optimism => "optimism",
+            NetworkName::Fantom => "fantom",
+            NetworkName::Unknown => "unknown",
+        };
+
+        write!(f, "{name}")
+    }
+}
+
+/// Maintained static list of supported Networks, the intervals target ~5minutes
+/// depending on the blockchain average block processing time
+pub static NETWORKS: Lazy<Vec<Network>> = Lazy::new(|| {
+    vec![
+        // Goerli (Ethereum Testnet): ~15 seconds
+        Network {
+            name: NetworkName::from_string("goerli"),
+            interval: 20,
+        },
+        // Mainnet (Ethereum): ~10-12 seconds
+        Network {
+            name: NetworkName::from_string("mainnet"),
+            interval: 30,
+        },
+        // Gnosis: ~5 seconds
+        Network {
+            name: NetworkName::from_string("gnosis"),
+            interval: 60,
+        },
+        // Local test network
+        Network {
+            name: NetworkName::from_string("hardhat"),
+            interval: 10,
+        },
+        // ArbitrumOne: ~0.25-1 second
+        Network {
+            name: NetworkName::from_string("arbitrum-one"),
+            interval: 600,
+        },
+        // ArbitrumGoerli (Arbitrum Testnet): ~.6 seconds
+        Network {
+            name: NetworkName::from_string("arbitrum-goerli"),
+            interval: 500,
+        },
+        // Avalanche: ~3-5 seconds
+        Network {
+            name: NetworkName::from_string("avalanche"),
+            interval: 60,
+        },
+        // Polygon: ~2 seconds
+        Network {
+            name: NetworkName::from_string("polygon"),
+            interval: 150,
+        },
+        // Celo: ~5-10 seconds
+        Network {
+            name: NetworkName::from_string("celo"),
+            interval: 30,
+        },
+        // Optimism: ~10-15 seconds
+        Network {
+            name: NetworkName::from_string("optimism"),
+            interval: 20,
+        },
+        // Fantom: ~2-3 seconds
+        Network {
+            name: NetworkName::from_string("optimism"),
+            interval: 100,
+        },
+    ]
+});


### PR DESCRIPTION
### Description

Require either private key or mnemonics as the input to build Graphcast ID wallet
Check
```rust
// Validity error
'Could not validate the supplied configurations: Validate the input: The registry subgraph did not contain an entry for the Graphcast ID to Indexer: Query response is unexpected: No indexer data queried from registry for GraphcastID: 0xe9a1cabd57700b17945fd81feefba82340d9568f'

// Missing argument error
thread 'main' panicked at 'Could not validate the supplied configurations: Validate the input: Must provide either private key or mnemonics', examples/ping-pong/src/main.rs:32:9

// Happy
DEBUG graphcast_sdk::config: Resolved indexer stake: 9884362578232080096242390
```

Refactored NETWORKS configurations to its own file

### Issue link (if applicable)
Resolves #139
Resolves #138