### PR TITLE
topic leveling, stake weight by active status, logs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,19 @@ pub struct Config {
     pub topics: Vec<String>,
     #[clap(
         long,
+        value_name = "COVERAGE",
+        value_enum,
+        // possible_values = ["comprehensive", "on-chain", "minimal"],
+        default_value = "on-chain",
+        env = "COVERAGE",
+        help = "Toggle for topic coverage level",
+        long_help = "Topic coverage level\ncomprehensive: Subscribe to on-chain topics, user defined static topics, and additional topics\n
+            on-chain: Subscribe to on-chain topics and user defined static topics\nminimal: Only subscribe to user defined static topics.\n
+            Default is set to on-chain coverage"
+    )]
+    pub coverage: CoverageLevel,
+    #[clap(
+        long,
         min_values = 0,
         default_value = "120",
         value_name = "COLLECT_MESSAGE_DURATION",
@@ -165,6 +178,13 @@ pub struct Config {
         env = "DISCORD_WEBHOOK"
     )]
     pub discord_webhook: Option<String>,
+}
+
+#[derive(clap::ValueEnum, Clone, Debug, Serialize, Deserialize)]
+pub enum CoverageLevel {
+    Minimal,
+    OnChain,
+    Comprehensive,
 }
 
 impl Config {

--- a/src/graphql/query_indexing_statuses.graphql
+++ b/src/graphql/query_indexing_statuses.graphql
@@ -3,6 +3,7 @@ query IndexingStatuses {
     subgraph
     synced
     health
+    node
     fatalError {
       handler
       message

--- a/src/graphql/schema_graph_node.graphql
+++ b/src/graphql/schema_graph_node.graphql
@@ -18,6 +18,7 @@ type IndexerDeployment {
   subgraph: String!
   synced: Boolean!
   health: String!
+  node: String!
   fatalError: IndexingError
   chains: [ChainIndexingStatus!]!
 }


### PR DESCRIPTION
### Description

- Allow coverage level to be configured for topic generation
  - comprehensive: Subscribe to on-chain topics, user defined static topics, and additional topics
  - on-chain: Subscribe to on-chain topics and user defined static topics
  - minimal: Only subscribe to user defined static topics.\n
  - Default is set to on-chain coverage
- Added `node` field to indexingStatuses
