### PR TITLE
fix: waku node setup with filter protocol only

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,4 +6,4 @@
 
 ### Checklist
 - [ ] Have you tested your changes? 
-- [ ] Does this PR include changes that require our documentation to be udpated, if so, have you created a PR on the docs repo to make the neccessary changes?
+- [ ] Does this PR include changes that require our documentation to be updated, if so, have you created a PR on the docs repo to make the neccessary changes?


### PR DESCRIPTION
### Description
- Updated the waku node config to only use filter protocol by disabling relay protocol and pubsub topic there.
- Removed related check on content topics.
- Updated a typo in pull request template

### Issue link (if applicable)
Got help from waku team waku-org/waku-rust-bindings#54
Resolves last task of #35

### Checklist
- [x] Have you tested your changes? 
- [x] Does this PR include changes that require our documentation to be updated, if so, have you created a PR on the docs repo to make the neccessary changes?
