### PR TITLE
Fix indexing statuses schema

### DIFF
--- a/src/graphcast_agent/message_typing.rs
+++ b/src/graphcast_agent/message_typing.rs
@@ -19,7 +19,7 @@ use crate::{
         QueryError,
     },
     networks::NetworkName,
-    NoncesMap,
+    NetworkBlockError, NoncesMap,
 };
 
 use super::{waku_handling::WakuHandlingError, MSG_REPLAY_LIMIT};
@@ -370,8 +370,12 @@ pub enum BuildMessageError {
     Signing,
     #[error("Could not encode message")]
     Encoding,
+    #[error("Could not decode message")]
+    Decoding,
     #[error("Could not pass message validity checks: {0}")]
     InvalidFields(anyhow::Error),
+    #[error("Could not build message with Network and BlockPointer: {0}")]
+    Network(NetworkBlockError),
     #[error("Could not derive fields from the existing message: {0}")]
     FieldDerivations(QueryError),
     #[error("{0}")]

--- a/src/graphql/schema_graph_node.graphql
+++ b/src/graphql/schema_graph_node.graphql
@@ -2,24 +2,37 @@ type BlockPointer {
   number: String!
   hash: String!
 }
-                                                                                                                                                                                                                                                        
+
+enum Health {
+  "Subgraph syncing normally"
+  healthy
+  "Subgraph syncing but with errors"
+  unhealthy
+  "Subgraph halted due to errors"
+  failed
+}
+
 type IndexingError {
   handler: String
+  block: BlockPointer
   message: String!
+  deterministic: Boolean!
 }
 
 type ChainIndexingStatus {
   network: String!
   latestBlock: BlockPointer
   chainHeadBlock: BlockPointer
+  lastHealthyBlock: BlockPointer
 }
 
 type IndexerDeployment {
   subgraph: String!
   synced: Boolean!
-  health: String!
-  node: String!
+  health: Health!
+  node: String
   fatalError: IndexingError
+  nonFatalErrors: [IndexingError!]!
   chains: [ChainIndexingStatus!]!
 }
 


### PR DESCRIPTION
### Description
There was a bug that some `indexingStatuses` has null `node` which is allowed by graph-node schema, but our definition made it strictly non-null. In this PR we update the field type, along with a few new fields (`latestHealthyBlock` for chains, `deterministic` for failed block, `Healthy` enum).

### Issue link (if applicable)
Helps with graphops/poi-radio#85

### Checklist
- [x] Have you tested your changes? 
- [x] Does this PR include changes that require our documentation to be updated, if so, have you created a PR on the docs repo to make the neccessary changes?
