### PR TITLE
feat: add metrics_host to config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -180,6 +180,13 @@ pub struct Config {
     pub discord_webhook: Option<String>,
     #[clap(
         long,
+        value_name = "METRICS_HOST",
+        help = "If set, the Radio will expose Prometheus metrics on the given host (off by default). This requires having a local Prometheus server running and scraping metrics on the given port.",
+        env = "METRICS_HOST"
+    )]
+    pub metrics_host: Option<String>,
+    #[clap(
+        long,
         value_name = "METRICS_PORT",
         help = "If set, the Radio will expose Prometheus metrics on the given port (off by default). This requires having a local Prometheus server running and scraping metrics on the given port.",
         env = "METRICS_PORT"

--- a/src/graphcast_agent/mod.rs
+++ b/src/graphcast_agent/mod.rs
@@ -159,25 +159,11 @@ impl GraphcastAgent {
     }
 
     /// Get the number of peers excluding self
-    pub fn number_of_peers(&self) -> u64 {
-        let count = self
-            .node_handle
-            .peer_count()
-            .unwrap_or({
-                debug!("Could not count the number of peers");
-                0
-            })
-            .try_into()
-            .unwrap_or({
-                debug!("Could not parse peer count usize to u64");
-                0
-            });
-
-        if count > 0 {
-            count - 1
-        } else {
+    pub fn number_of_peers(&self) -> usize {
+        self.node_handle.peer_count().unwrap_or({
+            debug!("Could not count the number of peers");
             0
-        }
+        })
     }
 
     /// Get identifiers of Radio content topics
@@ -202,11 +188,7 @@ impl GraphcastAgent {
         &self,
         identifier: String,
     ) -> Result<WakuContentTopic, GraphcastAgentError> {
-        debug!(
-            "Target content topics: {:#?}\nSubscribed content topics: {:#?}",
-            identifier,
-            self.content_topics.lock().await,
-        );
+        debug!("Target content topics: {:#?}\n", identifier,);
         match self
             .content_topics
             .lock()


### PR DESCRIPTION
### Description
- Add metrics host to configuration, "0.0.0.0" is the fallback.
- Remove -1 from peer_count for the Waku API

### Issue link (if applicable)
Follow up to #163

### Checklist
- [ ] Have you tested your changes? 
- [ ] Does this PR include changes that require our documentation to be updated, if so, have you created a PR on the docs repo to make the neccessary changes?
