### PR TITLE
subscription unsubscribe disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "graphcast-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphcast-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["GraphOps (axiomatic-aardvark, hopeyen)"]
 description="SDK to build Graphcast Radios"

--- a/changelog.md
+++ b/changelog.md
@@ -10,12 +10,14 @@ All notable changes to this project will be documented in this file.
 - Waku node setup with filter protocol only
 - IndexingStatuses graphQL schema allow null node
 - Add fantom network name
+- Ensure content topic lock gets released
 
 ### Documentation
 
 - Fix a grammatical error on the readme
 - Updated pull request template (#153)
 - New release process and changelog script
+- Update release process and script
 
 ### Features
 
@@ -62,6 +64,8 @@ All notable changes to this project will be documented in this file.
 - Replace bool prometheus_metrics with u16 metrics_port config var
 - Add new error variant to BuildMessage
 - Parse grt units, update log levels
+- Move config parsing to Radio
+- Update ping-pong Radio
 
 ## [0.0.13] - 2023-03-07
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,11 +10,11 @@ if [[ -z "$VERSION" ]]; then
   exit 1
 fi
 
-git-cliff -o CHANGELOG.md
+git-cliff -o changelog.md
 
 (
-  git add CHANGELOG.md \
-    && git commit -m "chore: release v$VERSION"
+  git add changelog.md Cargo.lock Cargo.toml scripts/release.sh \
+    && git commit -m "chore: release $VERSION"
 ) || true
 
 # Publish to crates.io

--- a/src/graphcast_agent/mod.rs
+++ b/src/graphcast_agent/mod.rs
@@ -28,7 +28,6 @@ use waku::{
     WakuPubSubTopic,
 };
 
-use crate::graphcast_agent::waku_handling::unsubscribe_peer;
 use crate::graphql::client_graph_node::{
     get_indexing_statuses, query_graph_node_network_block_hash,
 };
@@ -441,14 +440,17 @@ impl GraphcastAgent {
         if *cur_topics != new_topics {
             debug!("updating to new set of content topics: {:#?}", new_topics);
 
-            // Unsubscribe to the old content topics
-            unsubscribe_peer(&self.node_handle, &self.pubsub_topic, &cur_topics)
-                .expect("Could not connect and subscribe to the subtopics");
+            // TODO: Uncomment after a release that contains this issue
+            // https://github.com/waku-org/go-waku/pull/536/files
+            // // Unsubscribe to the old content topics
+            // if !cur_topics.is_empty() {
+            //     unsubscribe_peer(&self.node_handle, &self.pubsub_topic, &cur_topics)
+            //         .expect("Connect and unsubscribe to subtopics");
+            // }
 
             // Subscribe to the new content topics
             filter_peer_subscriptions(&self.node_handle, &self.pubsub_topic, &new_topics)
-                .expect("Could not connect and subscribe to the subtopics");
-
+                .expect("Connect and subscribe to subtopics");
             *cur_topics = new_topics;
         }
         drop(cur_topics);


### PR DESCRIPTION
### Description

Comment out unsubscribe until waku-rust-binding creates a new crate that includes this fix: https://github.com/waku-org/go-waku/pull/536 
- Agents temporarily cannot unsubscribe to older topics

### Checklist
- [] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
