### PR TITLE
feat: validation mechanism options for msg sender identity

### DIFF
--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -69,10 +69,11 @@ async fn main() {
     // GraphcastAgentConfig defines the configuration that the SDK expects from all Radios, regardless of their specific functionality
     let graphcast_agent_config = GraphcastAgentConfig::new(
         config.private_key.expect("No private key provided"),
+        config.indexer_address,
         radio_name,
         config.registry_subgraph,
         config.network_subgraph,
-        config.graph_node_endpoint.clone(),
+        config.graph_node_endpoint,
         None,
         Some("testnet".to_string()),
         Some(subtopics),
@@ -84,6 +85,7 @@ async fn main() {
         // Example ENR address
         Some(vec![String::from("enr:-JK4QBcfVXu2YDeSKdjF2xE5EDM5f5E_1Akpkv_yw_byn1adESxDXVLVjapjDvS_ujx6MgWDu9hqO_Az_CbKLJ8azbMBgmlkgnY0gmlwhAVOUWOJc2VjcDI1NmsxoQOUZIqKLk5xkiH0RAFaMGrziGeGxypJ03kOod1-7Pum3oN0Y3CCfJyDdWRwgiMohXdha3UyDQ")]),
         None,
+        config.id_validation,
     )
     .await
     .unwrap_or_else(|e| panic!("Could not create GraphcastAgentConfig: {e}"));

--- a/src/callbook.rs
+++ b/src/callbook.rs
@@ -6,7 +6,7 @@ use crate::graphql::client_graph_node::{
     get_indexing_statuses, query_graph_node_network_block_hash,
 };
 use crate::graphql::client_network::{query_network_subgraph, Network};
-use crate::graphql::client_registry::query_registry_indexer;
+use crate::graphql::client_registry::query_registry;
 use crate::graphql::QueryError;
 
 #[derive(Clone, Debug, Getters, Serialize, Deserialize, PartialEq)]
@@ -40,11 +40,8 @@ impl CallBook {
             .await
     }
 
-    pub async fn registered_indexer(
-        &self,
-        graphcast_id_address: String,
-    ) -> Result<String, QueryError> {
-        query_registry_indexer(self.graphcast_registry.clone(), graphcast_id_address).await
+    pub async fn registered_indexer(&self, wallet_address: String) -> Result<String, QueryError> {
+        query_registry(self.graphcast_registry.clone(), wallet_address).await
     }
 
     pub async fn indexing_statuses(

--- a/src/graphcast_agent/waku_handling.rs
+++ b/src/graphcast_agent/waku_handling.rs
@@ -316,7 +316,7 @@ pub fn setup_node_handle(
     let mut discv5_nodes: Vec<String> = get_dns_nodes(pubsub_topic)
         .into_iter()
         .filter(|d| d.enr.is_some())
-        .map(|d| d.enr.unwrap().to_string())
+        .map(|d| d.enr.unwrap().to_base64())
         .collect::<Vec<String>>();
     discv5_nodes.extend(discv5_enrs.clone());
     match env::var("WAKU_NODE_BOOT").ok() {
@@ -451,6 +451,7 @@ pub async fn handle_signal<
                         &graphcast_agent.nonces,
                         graphcast_agent.callbook.clone(),
                         graphcast_agent.graphcast_identity.graphcast_id.clone(),
+                        graphcast_agent.id_validation.clone(),
                     )
                     .await
                     .map_err(|e| WakuHandlingError::InvalidMessage(e.to_string()))

--- a/src/graphql/client_graph_account.rs
+++ b/src/graphql/client_graph_account.rs
@@ -1,0 +1,77 @@
+use crate::{graphql::QueryError, Account};
+use graphql_client::{GraphQLQuery, Response};
+
+/// Derived GraphQL Query to Network Subgraph
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/schema_graph_account.graphql",
+    query_path = "src/graphql/query_graph_account.graphql",
+    response_derives = "Debug, Serialize, Deserialize"
+)]
+pub struct GraphAccount;
+
+/// Query network subgraph for Network data
+/// Contains indexer address, stake, allocations
+/// and graph network minimum indexer stake requirement
+pub async fn query_graph_account(
+    url: String,
+    operator: String,
+    account: String,
+) -> Result<Account, QueryError> {
+    // Can refactor for all types of queries
+    let variables: graph_account::Variables = graph_account::Variables {
+        // Do not supply operator address if operator is already a graph account
+        operator_addr: if operator == account {
+            vec![]
+        } else {
+            vec![operator.clone()]
+        },
+        account_addr: account.clone(),
+    };
+    let request_body = GraphAccount::build_query(variables);
+    let client = reqwest::Client::builder()
+        .user_agent("network-subgraph")
+        .build()?;
+    let request = client.post(url.clone()).json(&request_body);
+    let response = request.send().await?.error_for_status()?;
+    let response_body: Response<graph_account::ResponseData> = response.json().await?;
+
+    if let Some(errors) = response_body.errors.as_deref() {
+        let e = &errors[0];
+        if e.message == "indexing_error" {
+            return Err(QueryError::IndexingError);
+        } else {
+            return Err(QueryError::Other(anyhow::anyhow!("{}", e.message)));
+        }
+    }
+    let data = response_body.data.ok_or_else(|| {
+        QueryError::ParseResponseError(format!(
+            "Missing response data from network subgraph for account {} with agent {}",
+            account, operator
+        ))
+    })?;
+
+    let agent: String = data
+        .graph_accounts
+        .first()
+        .and_then(|x| x.operators.first().map(|x| x.id.clone()))
+        .ok_or_else(|| {
+            QueryError::ParseResponseError(String::from(
+                "Network subgraph does not have a match for agent account and graph account",
+            ))
+        })?;
+
+    let account: String = data
+        .graph_accounts
+        .first()
+        .map(|x| x.id.clone())
+        .ok_or_else(|| {
+            QueryError::ParseResponseError(String::from(
+                "Network subgraph does not have a match for graph account",
+            ))
+        })?;
+
+    let account = Account { agent, account };
+
+    Ok(account)
+}

--- a/src/graphql/client_registry.rs
+++ b/src/graphql/client_registry.rs
@@ -29,12 +29,12 @@ pub async fn perform_graphcast_id_indexer_query(
 }
 
 /// Construct GraphQL variables and parse result for indexer address
-pub async fn query_registry_indexer(
+pub async fn query_registry(
     registry_subgraph_endpoint: String,
-    graphcast_id_address: String,
+    wallet_address: String,
 ) -> Result<String, QueryError> {
     let variables: set_graphcast_ids::Variables = set_graphcast_ids::Variables {
-        address: graphcast_id_address.clone(),
+        address: wallet_address.clone(),
     };
     let queried_result =
         perform_graphcast_id_indexer_query(registry_subgraph_endpoint.clone(), variables).await?;
@@ -54,11 +54,11 @@ pub async fn query_registry_indexer(
             .first()
             .map(|event| event.indexer.clone())
             .ok_or(QueryError::ParseResponseError(format!(
-                "No indexer data queried from registry for GraphcastID: {graphcast_id_address}"
+                "No indexer data queried from registry for GraphcastID: {wallet_address}"
             )))
     } else {
         Err(QueryError::ParseResponseError(format!(
-            "No response data from registry for graphcastID {graphcast_id_address}"
+            "No response data from registry for GraphcastID: {wallet_address}"
         )))
     }
 }

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -1,3 +1,4 @@
+pub mod client_graph_account;
 pub mod client_graph_node;
 pub mod client_network;
 pub mod client_registry;
@@ -42,7 +43,6 @@ mod tests {
             "100000.000000000000000000",
         );
         assert_eq!(add_decimal("0"), "0.0");
-        println!("result: {:#?}", add_decimal("30921273477321769415119223"));
         assert_eq!(
             add_decimal("30921273477321769415119223"),
             "30921273.477321769415119223",

--- a/src/graphql/query_graph_account.graphql
+++ b/src/graphql/query_graph_account.graphql
@@ -1,0 +1,18 @@
+query GraphAccount($account_addr: String!, $operator_addr: [String!]!) {
+  graphAccounts(where:{
+    operators_contains: $operator_addr,
+    id: $account_addr 
+  }) {
+    id
+    operators{
+      id
+    }
+    subgraphs{
+      id
+    }
+    indexer {
+      id
+      stakedTokens
+    }
+  }
+}

--- a/src/graphql/query_network.graphql
+++ b/src/graphql/query_network.graphql
@@ -1,4 +1,4 @@
-query NetworkSubgraph($address: String!) {
+query IndexerStatus($address: String!) {
   indexer(id: $address) {
     stakedTokens
     allocations{

--- a/src/graphql/schema_graph_account.graphql
+++ b/src/graphql/schema_graph_account.graphql
@@ -1,0 +1,23 @@
+type Subgraph {
+  id: String!
+}
+
+type Indexer {
+  id: String!
+  stakedTokens: String!
+}
+
+type Operator {
+  id: String!
+}
+
+type GraphAccount {
+  id: String!
+  operators: [Operator!]!
+  subgraphs: [Subgraph!]!
+  indexer: Indexer
+}
+
+type Query {
+  graphAccounts(account_addr: String!, operator_addr: String!): [GraphAccount!]!
+}


### PR DESCRIPTION
### Description

- Add options for ways to validate the sender for a Graphcast Message. The option is used for validating local account identity during pre-operational validation and when the radio receives remote messages.
- Add a field `graph_account` to `GraphcastMessage` for resolution between `indexer_opeartor` and `indexer_address` since the relationship can be N-to-N. The sender of the message must be able to resolve into the claimed `graph_account` through the configured validation mechanism
- Add new queries for `GraphAccount`, laying the groundwork for checking message senders who can be non-indexers. It is later possible to utilize "subgraphs{id}" to check for subgraph ownerships so that subgraph owners can send GraphcastMessage as well.
- Fix DNS enr info encoding as base64 

Available options
```
- no-check: all messages signer is valid, 
- valid-address: signer needs to be an valid Eth address, 
- graphcast-registered: must be registered at Graphcast Registry, 
- graph-network-account: must be a Graph account, 
- registered-indexer: must be registered at Graphcast Registry, correspond to and Indexer statisfying indexer minimum stake requirement, 
- indexer: must be registered at Graphcast Registry or is a Graph Account, correspond to and Indexer statisfying indexer minimum stake requirement
```

### Issue link (if applicable)
Resolve #204

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
