### PR TITLE
refactor: String -> &str

### DIFF
--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -112,7 +112,7 @@ async fn main() {
             .send_message(
                 // The identifier can be any string that suits your Radio logic
                 // If it doesn't matter for your Radio logic (like in this case), you can just use a UUID or a hardcoded string
-                "ping-pong-content-topic".to_string(),
+                "ping-pong-content-topic",
                 network,
                 block_number,
                 payload,

--- a/src/callbook.rs
+++ b/src/callbook.rs
@@ -31,26 +31,21 @@ impl CallBook {
             graph_network,
         }
     }
-    pub async fn block_hash(
-        &self,
-        network: String,
-        block_number: u64,
-    ) -> Result<String, QueryError> {
-        query_graph_node_network_block_hash(self.graph_node_status.clone(), network, block_number)
-            .await
+    pub async fn block_hash(&self, network: &str, block_number: u64) -> Result<String, QueryError> {
+        query_graph_node_network_block_hash(&self.graph_node_status, network, block_number).await
     }
 
-    pub async fn registered_indexer(&self, wallet_address: String) -> Result<String, QueryError> {
-        query_registry(self.graphcast_registry.clone(), wallet_address).await
+    pub async fn registered_indexer(&self, wallet_address: &str) -> Result<String, QueryError> {
+        query_registry(&self.graphcast_registry, wallet_address).await
     }
 
     pub async fn indexing_statuses(
         &self,
     ) -> Result<Vec<IndexingStatusesIndexingStatuses>, QueryError> {
-        get_indexing_statuses(self.graph_node_status.clone()).await
+        get_indexing_statuses(&self.graph_node_status).await
     }
 
-    pub async fn network_subgraph(&self, indexer_address: String) -> Result<Network, QueryError> {
-        query_network_subgraph(self.graph_network.clone(), indexer_address).await
+    pub async fn network_subgraph(&self, indexer_address: &str) -> Result<Network, QueryError> {
+        query_network_subgraph(&self.graph_network, indexer_address).await
     }
 }

--- a/src/graphcast_agent/message_typing.rs
+++ b/src/graphcast_agent/message_typing.rs
@@ -37,14 +37,12 @@ fn prepare_nonces(
 }
 
 pub async fn get_indexer_stake(
-    indexer_address: String,
+    indexer_address: &str,
     network_subgraph: &str,
 ) -> Result<f32, QueryError> {
-    Ok(
-        query_network_subgraph(network_subgraph.to_string(), indexer_address)
-            .await?
-            .indexer_stake(),
-    )
+    Ok(query_network_subgraph(network_subgraph, indexer_address)
+        .await?
+        .indexer_stake())
 }
 
 /// GraphcastMessage type casts over radio payload
@@ -331,8 +329,8 @@ impl<
     /// Check timestamp: prevent messages with incorrect graph node's block provider
     pub async fn valid_hash(&self, graph_node_endpoint: &str) -> Result<&Self, BuildMessageError> {
         let block_hash: String = query_graph_node_network_block_hash(
-            graph_node_endpoint.to_string(),
-            self.network.clone(),
+            graph_node_endpoint,
+            &self.network,
             self.block_number,
         )
         .await

--- a/src/graphcast_agent/mod.rs
+++ b/src/graphcast_agent/mod.rs
@@ -147,7 +147,7 @@ impl GraphcastAgentConfig {
             }
         };
         let _ = verified_account.valid_indexer(&self.network_subgraph).await;
-        let _ = get_indexing_statuses(self.graph_node_endpoint.to_string())
+        let _ = get_indexing_statuses(&self.graph_node_endpoint)
             .await
             .map_err(|e| {
                 ConfigError::ValidateInput(format!(
@@ -354,7 +354,7 @@ impl GraphcastAgent {
     /// Error if topic doesn't exist
     pub async fn match_content_topic(
         &self,
-        identifier: String,
+        identifier: &str,
     ) -> Result<WakuContentTopic, GraphcastAgentError> {
         trace!(topic = identifier, "Target content topic");
         match self
@@ -410,12 +410,12 @@ impl GraphcastAgent {
             + async_graphql::OutputType,
     >(
         &self,
-        identifier: String,
+        identifier: &str,
         network: NetworkName,
         block_number: u64,
         payload: Option<T>,
     ) -> Result<String, GraphcastAgentError> {
-        let content_topic = self.match_content_topic(identifier.clone()).await?;
+        let content_topic = self.match_content_topic(identifier).await?;
         trace!(
             topic = tracing::field::debug(&content_topic),
             "Selected content topic from subscriptions"
@@ -423,7 +423,7 @@ impl GraphcastAgent {
 
         let block_hash = self
             .callbook
-            .block_hash(network.to_string(), block_number)
+            .block_hash(&network.to_string(), block_number)
             .await?;
 
         // Check network before sending a message
@@ -432,7 +432,7 @@ impl GraphcastAgent {
 
         GraphcastMessage::build(
             &self.graphcast_identity.wallet,
-            identifier,
+            identifier.to_string(),
             payload,
             network,
             block_number,

--- a/src/graphql/client_graph_account.rs
+++ b/src/graphql/client_graph_account.rs
@@ -15,9 +15,9 @@ pub struct GraphAccount;
 /// Contains indexer address, stake, allocations
 /// and graph network minimum indexer stake requirement
 pub async fn query_graph_account(
-    url: String,
-    operator: String,
-    account: String,
+    url: &str,
+    operator: &str,
+    account: &str,
 ) -> Result<Account, QueryError> {
     // Can refactor for all types of queries
     let variables: graph_account::Variables = graph_account::Variables {
@@ -25,15 +25,15 @@ pub async fn query_graph_account(
         operator_addr: if operator == account {
             vec![]
         } else {
-            vec![operator.clone()]
+            vec![operator.to_string()]
         },
-        account_addr: account.clone(),
+        account_addr: account.to_string(),
     };
     let request_body = GraphAccount::build_query(variables);
     let client = reqwest::Client::builder()
         .user_agent("network-subgraph")
         .build()?;
-    let request = client.post(url.clone()).json(&request_body);
+    let request = client.post(url).json(&request_body);
     let response = request.send().await?.error_for_status()?;
     let response_body: Response<graph_account::ResponseData> = response.json().await?;
     trace!(
@@ -56,7 +56,7 @@ pub async fn query_graph_account(
     })?;
 
     let agent: String = if operator == account {
-        account.clone()
+        account.to_string()
     } else {
         data.graph_accounts
             .first()

--- a/src/graphql/client_graph_node.rs
+++ b/src/graphql/client_graph_node.rs
@@ -28,7 +28,7 @@ pub struct BlockHashFromNumber;
 
 /// Query graph node for Block hash
 pub async fn perform_block_hash_from_number(
-    graph_node_endpoint: String,
+    graph_node_endpoint: &str,
     variables: block_hash_from_number::Variables,
 ) -> Result<reqwest::Response, reqwest::Error> {
     let request_body = BlockHashFromNumber::build_query(variables);
@@ -44,16 +44,15 @@ pub async fn perform_block_hash_from_number(
 /// Construct GraphQL variables and parse result for Proof of Indexing.
 /// For other radio use cases, provide a function that returns a string
 pub async fn query_graph_node_network_block_hash(
-    graph_node_endpoint: String,
-    network: String,
+    graph_node_endpoint: &str,
+    network: &str,
     block_number: u64,
 ) -> Result<String, QueryError> {
     let variables: block_hash_from_number::Variables = block_hash_from_number::Variables {
-        network: network.clone(),
+        network: network.to_string(),
         block_number: block_number.try_into().unwrap(),
     };
-    let queried_result =
-        perform_block_hash_from_number(graph_node_endpoint.clone(), variables).await?;
+    let queried_result = perform_block_hash_from_number(graph_node_endpoint, variables).await?;
     trace!(
         result = tracing::field::debug(&queried_result),
         "Query result for graph node network block hash"
@@ -83,7 +82,7 @@ pub async fn query_graph_node_network_block_hash(
 
 /// Query graph node for Indexing Statuses
 pub async fn perform_indexing_statuses(
-    graph_node_endpoint: String,
+    graph_node_endpoint: &str,
     variables: indexing_statuses::Variables,
 ) -> Result<reqwest::Response, reqwest::Error> {
     let request_body = IndexingStatuses::build_query(variables);
@@ -98,10 +97,10 @@ pub async fn perform_indexing_statuses(
 
 /// This function get all indexing statuses from Graph node status endpoint
 pub async fn get_indexing_statuses(
-    graph_node_endpoint: String,
+    graph_node_endpoint: &str,
 ) -> Result<Vec<IndexingStatusesIndexingStatuses>, QueryError> {
     let variables: indexing_statuses::Variables = indexing_statuses::Variables {};
-    let queried_result = perform_indexing_statuses(graph_node_endpoint.clone(), variables).await?;
+    let queried_result = perform_indexing_statuses(graph_node_endpoint, variables).await?;
     trace!(
         result = tracing::field::debug(&queried_result),
         "Query result for indexing statuses"

--- a/src/graphql/client_network.rs
+++ b/src/graphql/client_network.rs
@@ -19,12 +19,12 @@ pub struct IndexerStatus;
 /// Contains indexer address, stake, allocations
 /// and graph network minimum indexer stake requirement
 pub async fn query_network_subgraph(
-    url: String,
-    indexer_address: String,
+    url: &str,
+    indexer_address: &str,
 ) -> Result<Network, QueryError> {
     // Can refactor for all types of queries
     let variables: indexer_status::Variables = indexer_status::Variables {
-        address: indexer_address.clone(),
+        address: indexer_address.to_string(),
     };
     let request_body = IndexerStatus::build_query(variables);
     let client = reqwest::Client::builder()
@@ -55,7 +55,7 @@ pub async fn query_network_subgraph(
     };
 
     let indexer = data.indexer.and_then(|x| {
-        match Some(grt_gwei_string_to_f32(x.staked_tokens)).transpose() {
+        match Some(grt_gwei_string_to_f32(&x.staked_tokens)).transpose() {
             Ok(token) => {
                 let allocations: Vec<Allocation> = x.allocations.map(|allocs| {
                     allocs
@@ -87,7 +87,7 @@ pub async fn query_network_subgraph(
         indexer,
         graph_network: GraphNetwork {
             minimum_indexer_stake: grt_gwei_string_to_f32(
-                data.graph_network.minimum_indexer_stake,
+                &data.graph_network.minimum_indexer_stake,
             )?,
         },
     })

--- a/src/graphql/client_registry.rs
+++ b/src/graphql/client_registry.rs
@@ -15,7 +15,7 @@ pub struct SetGraphcastIds;
 
 /// Query registry subgraph endpoint for resolving Graphcast ID and indexer address
 pub async fn perform_graphcast_id_indexer_query(
-    registry_subgraph_endpoint: String,
+    registry_subgraph_endpoint: &str,
     variables: set_graphcast_ids::Variables,
 ) -> Result<reqwest::Response, reqwest::Error> {
     let request_body = SetGraphcastIds::build_query(variables);
@@ -30,14 +30,14 @@ pub async fn perform_graphcast_id_indexer_query(
 
 /// Construct GraphQL variables and parse result for indexer address
 pub async fn query_registry(
-    registry_subgraph_endpoint: String,
-    wallet_address: String,
+    registry_subgraph_endpoint: &str,
+    wallet_address: &str,
 ) -> Result<String, QueryError> {
     let variables: set_graphcast_ids::Variables = set_graphcast_ids::Variables {
-        address: wallet_address.clone(),
+        address: wallet_address.to_string(),
     };
     let queried_result =
-        perform_graphcast_id_indexer_query(registry_subgraph_endpoint.clone(), variables).await?;
+        perform_graphcast_id_indexer_query(registry_subgraph_endpoint, variables).await?;
     trace!(
         result = tracing::field::debug(&queried_result),
         "Query result for registry indexer"

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -17,8 +17,8 @@ pub enum QueryError {
     Other(anyhow::Error),
 }
 
-pub fn grt_gwei_string_to_f32(input: String) -> Result<f32, QueryError> {
-    add_decimal(&input)
+pub fn grt_gwei_string_to_f32(input: &str) -> Result<f32, QueryError> {
+    add_decimal(input)
         .parse::<f32>()
         .map_err(|e| QueryError::ParseResponseError(e.to_string()))
 }
@@ -52,19 +52,19 @@ mod tests {
     #[test]
     fn test_grt_gwei_string_to_f32() {
         // valid inputs
-        assert!(grt_gwei_string_to_f32("100000000000000000000000".to_string()).is_ok());
+        assert!(grt_gwei_string_to_f32("100000000000000000000000").is_ok());
         assert_eq!(
-            grt_gwei_string_to_f32("100000000000000000000000".to_string()).unwrap(),
+            grt_gwei_string_to_f32("100000000000000000000000").unwrap(),
             100000.0,
         );
-        assert!(grt_gwei_string_to_f32("0".to_string()).is_ok());
-        assert!(grt_gwei_string_to_f32("30921273477321769415119223".to_string()).is_ok());
+        assert!(grt_gwei_string_to_f32("0").is_ok());
+        assert!(grt_gwei_string_to_f32("30921273477321769415119223").is_ok());
         assert_eq!(
-            grt_gwei_string_to_f32("30921273477321769415119223".to_string()).unwrap(),
+            grt_gwei_string_to_f32("30921273477321769415119223").unwrap(),
             30921273.477321769415119223,
         );
 
         // invalid inputs
-        assert!(grt_gwei_string_to_f32("abc".to_string()).is_err(),);
+        assert!(grt_gwei_string_to_f32("abc").is_err(),);
     }
 }


### PR DESCRIPTION
### Description
There was a lot of use of the owned String type without necessity. Cases where the value is being used for comparison, or just to read &str is a better option. Unnecessary clones were removed too and .to_string() calls added as needed. Functions like ::new still use String to makes things easier.

I didn't check on `poi-radio`, but I think a few calls might need to change there.

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
