### PR TITLE
generic message decode + subgraph owner check

### DIFF
--- a/examples/ping-pong/src/config.rs
+++ b/examples/ping-pong/src/config.rs
@@ -20,7 +20,7 @@ pub struct Config {
         env = "GRAPH_NODE_STATUS_ENDPOINT",
         help = "API endpoint to the Graph Node Status Endpoint"
     )]
-    pub graph_node_endpoint: String,
+    pub graph_node_endpoint: Option<String>,
     #[clap(
         long,
         value_name = "KEY",

--- a/examples/ping-pong/src/config.rs
+++ b/examples/ping-pong/src/config.rs
@@ -77,6 +77,7 @@ pub struct Config {
         value_name = "ID_VALIDATION",
         value_enum,
         env = "ID_VALIDATION",
+        default_value = "valid-address",
         help = "Identity validation mechanism for senders (message signers)",
         long_help = "Identity validation mechanism for senders (message signers)\n
         no-check: all messages signer is valid, \n
@@ -86,7 +87,7 @@ pub struct Config {
         registered-indexer: must be registered at Graphcast Registry, correspond to and Indexer statisfying indexer minimum stake requirement, \n
         indexer: must be registered at Graphcast Registry or is a Graph Account, correspond to and Indexer statisfying indexer minimum stake requirement"
     )]
-    pub id_validation: Option<IdentityValidation>,
+    pub id_validation: IdentityValidation,
 }
 
 impl Config {

--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -96,7 +96,7 @@ async fn main() {
 
     // The handler specifies what to do with incoming messages.
     // This is where you can define multiple message types and how they gets handled by the radio
-    // by chaining radio payload typed decoder and handler functions
+    // by chaining radio payload typed decode and handler functions
     tokio::spawn(async move {
         for msg in waku_msg_receiver {
             trace!(
@@ -105,7 +105,7 @@ async fn main() {
             let _ = GRAPHCAST_AGENT
                 .get()
                 .expect("Could not retrieve Graphcast agent")
-                .decoder::<SimpleMessage>(msg.payload())
+                .decode::<SimpleMessage>(msg.payload())
                 .await
                 .map(|msg| {
                     msg.payload.radio_handler();

--- a/examples/ping-pong/src/types.rs
+++ b/examples/ping-pong/src/types.rs
@@ -5,6 +5,7 @@ use ethers_derive_eip712::*;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 
+/// Make a test radio type
 #[derive(Eip712, EthAbiType, Clone, Message, Serialize, Deserialize, SimpleObject)]
 #[eip712(
     name = "Graphcast Ping-Pong Radio",
@@ -12,16 +13,16 @@ use serde::{Deserialize, Serialize};
     chain_id = 1,
     verifying_contract = "0xc944e90c64b2c07662a292be6244bdf05cda44a7"
 )]
-pub struct RadioPayloadMessage {
+pub struct SimpleMessage {
     #[prost(string, tag = "1")]
     pub identifier: String,
     #[prost(string, tag = "2")]
     pub content: String,
 }
 
-impl RadioPayloadMessage {
+impl SimpleMessage {
     pub fn new(identifier: String, content: String) -> Self {
-        RadioPayloadMessage {
+        SimpleMessage {
             identifier,
             content,
         }

--- a/examples/ping-pong/src/types.rs
+++ b/examples/ping-pong/src/types.rs
@@ -2,8 +2,24 @@ use async_graphql::SimpleObject;
 use ethers_contract::EthAbiType;
 use ethers_core::types::transaction::eip712::Eip712;
 use ethers_derive_eip712::*;
+use graphcast_sdk::graphcast_agent::GraphcastAgent;
 use prost::Message;
 use serde::{Deserialize, Serialize};
+
+// Import the OnceCell container for lazy initialization of global/static data
+use once_cell::sync::OnceCell;
+use std::sync::{Arc, Mutex};
+
+/// A global static (singleton) instance of A GraphcastMessage vector.
+/// It is used to save incoming messages after they've been validated, in order
+/// defer their processing for later, because async code is required for the processing but
+/// it is not allowed in the handler itself.
+pub static MESSAGES: OnceCell<Arc<Mutex<Vec<SimpleMessage>>>> = OnceCell::new();
+
+/// The Graphcast Agent instance must be a global static variable (for the time being).
+/// This is because the Radio handler requires a static immutable context and
+/// the handler itself is being passed into the Graphcast Agent, so it needs to be static as well.
+pub static GRAPHCAST_AGENT: OnceCell<GraphcastAgent> = OnceCell::new();
 
 /// Make a test radio type
 #[derive(Eip712, EthAbiType, Clone, Message, Serialize, Deserialize, SimpleObject)]
@@ -26,5 +42,14 @@ impl SimpleMessage {
             identifier,
             content,
         }
+    }
+
+    pub fn radio_handler(&self) {
+        MESSAGES
+            .get()
+            .expect("Could not retrieve messages")
+            .lock()
+            .expect("Could not get lock on messages")
+            .push(self.clone());
     }
 }

--- a/src/graphcast_agent/message_typing.rs
+++ b/src/graphcast_agent/message_typing.rs
@@ -180,11 +180,7 @@ impl<
         if id_validation == &IdentityValidation::NoCheck {
             return Ok(self);
         };
-        trace!(
-            remote_resolved = tracing::field::debug(&self.remote_account(local_sender_id.clone())),
-            id = tracing::field::debug(&id_validation),
-            "Check account"
-        );
+        trace!(id = tracing::field::debug(&id_validation), "Check account");
         // Should optionally chain valid_owner check
         let _ = self
             .remote_account(local_sender_id)?
@@ -460,6 +456,25 @@ mod tests {
                     content: String::from("Ping") },
             signature: String::from("60a4b735acaf0c2490a51e34e0b799080c5c144ee2fe5dc9499465c490a4c5e946609c7d27d3b39cf4110d4f9402bac7f89cf2bd3850ae816506e638cde1a3c11c")
         }
+    }
+
+    #[tokio::test]
+    async fn test_signature() {
+        let wallet = dummy_wallet();
+        let msg = GraphcastMessage::build(
+            &wallet,
+            String::from("ping-pong-content-topic"),
+            String::from("0xe9a1cabd57700b17945fd81feefba82340d9568f"),
+            1688742308,
+            SimpleMessage {
+                identifier: String::from("table"),
+                content: String::from("Ping"),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(wallet_address(&wallet) == msg.recover_sender_address().unwrap());
     }
 
     #[tokio::test]

--- a/src/graphcast_agent/message_typing.rs
+++ b/src/graphcast_agent/message_typing.rs
@@ -181,7 +181,7 @@ impl<
             return Ok(self);
         };
         trace!(id = tracing::field::debug(&id_validation), "Check account");
-        // Should optionally chain valid_owner check
+
         let _ = self
             .remote_account(local_sender_id)?
             .verify(network_subgraph, registry_subgraph, id_validation)
@@ -367,7 +367,7 @@ pub enum IdentityValidation {
     // valid Graph indexer or Graphcast Registered Indexer
     Indexer,
     // valid Graph indexer, Graphcast Registered Indexer, or Message identifier owner / subgraph owner
-    // Does not include Curator or Indexer Delegator
+    // Does not include Curator or Delegator
     SubgraphStaker,
 }
 
@@ -414,8 +414,6 @@ mod tests {
     /// Create a random wallet
     fn dummy_wallet() -> Wallet<SigningKey> {
         Wallet::new(&mut thread_rng())
-        // let wallet =
-        // build_wallet("baf5c93f0c8aee3b945f33b9192014e83d50cec25f727a13460f6ef1eb6a5844").unwrap();
     }
 
     // Signature generated from goerli main indexer account

--- a/src/graphcast_agent/mod.rs
+++ b/src/graphcast_agent/mod.rs
@@ -433,8 +433,8 @@ impl GraphcastAgent {
         GraphcastMessage::build(
             &self.graphcast_identity.wallet,
             identifier.to_string(),
-            nonce,
             self.graphcast_identity.graph_account.clone(),
+            nonce,
             payload,
         )
         .await

--- a/src/graphcast_agent/waku_handling.rs
+++ b/src/graphcast_agent/waku_handling.rs
@@ -410,26 +410,22 @@ pub fn boot_node_handle(
 /// Parse and validate incoming message
 pub async fn handle_signal(
     signal: Signal,
-    // graphcast_agent: &GraphcastAgent,
     old_message_ids: &Arc<AsyncMutex<HashSet<String>>>,
 ) -> Result<WakuMessage, WakuHandlingError> {
     // Do not accept messages that were already received or sent by self
-    // let old_message_ids: &Arc<AsyncMutex<HashSet<String>>> = &graphcast_agent.old_message_ids;
     let mut ids = old_message_ids.lock().await;
     match signal.event() {
         waku::Event::WakuMessage(event) => {
-            trace!(
-                "Received message id: {:#?}\n old ids: {:#?}",
-                event.message_id(),
-                ids
-            );
-            if ids.contains(event.message_id()) {
-                trace!("Skip repeated message");
-                return Err(WakuHandlingError::InvalidMessage(
-                    "Skip repeated message".to_string(),
-                ));
+            let msg_id = event.message_id();
+            trace!(msg_id, "Received message id",);
+            if ids.contains(msg_id) {
+                trace!(msg_id, "Skip repeated message");
+                return Err(WakuHandlingError::InvalidMessage(format!(
+                    "Skip repeated message: {:#?}",
+                    msg_id
+                )));
             };
-            ids.insert(event.message_id().clone());
+            ids.insert(msg_id.to_string());
             Ok(event.waku_message().clone())
         }
 

--- a/src/graphql/client_graph_account.rs
+++ b/src/graphql/client_graph_account.rs
@@ -198,3 +198,41 @@ pub async fn subgraph_hash_by_id(
 
     Ok(hashes)
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_owned_subgraphs() {
+        let network_subgraph =
+            "https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-goerli";
+        let account = "0xe9a1cabd57700b17945fd81feefba82340d9568f";
+        let owned_subgraphs = owned_subgraphs(network_subgraph, account).await;
+
+        assert!(owned_subgraphs.is_ok());
+        // Current subgraph number
+        assert!(owned_subgraphs.unwrap().len() > 5);
+    }
+    #[tokio::test]
+    async fn test_subgraph_linked() {
+        let network_subgraph =
+            "https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-mainnet";
+        let account = "0x00000444e5a1a667663b0adfd853e8efa0470698";
+        let subgraph_id = "0x00000444e5a1a667663b0adfd853e8efa0470698-0";
+        let subgraph_hashes = subgraph_hash_by_id(network_subgraph, account, subgraph_id)
+            .await
+            .unwrap();
+
+        assert!(subgraph_hashes.contains(&String::from(
+            "QmQQeCUjemEf6urSR5SUvvdRTn9ZXdctHwuxjPJoFJD6wR"
+        )));
+        assert!(subgraph_hashes.contains(&String::from(
+            "QmXpLT9V82VMYbBCDKTiTAEpG3g6CD3DygRhxmUTiDu9eF"
+        )));
+        assert!(subgraph_hashes.contains(&String::from(
+            "QmfDJFYaDX7BdwT6rYa8Bx71vPjTueUVDN99pdwFgysDiZ"
+        )));
+    }
+}

--- a/src/graphql/client_graph_account.rs
+++ b/src/graphql/client_graph_account.rs
@@ -11,15 +11,12 @@ use tracing::trace;
 )]
 pub struct GraphAccount;
 
-/// Query network subgraph for Network data
-/// Contains indexer address, stake, allocations
-/// and graph network minimum indexer stake requirement
+/// Query network subgraph for Graph account
 pub async fn query_graph_account(
     url: &str,
     operator: &str,
     account: &str,
 ) -> Result<Account, QueryError> {
-    // Can refactor for all types of queries
     let variables: graph_account::Variables = graph_account::Variables {
         // Do not supply operator address if operator is already a graph account
         operator_addr: if operator == account {
@@ -81,4 +78,123 @@ pub async fn query_graph_account(
     let account = Account { agent, account };
 
     Ok(account)
+}
+
+/// Query network subgraph for subgraph ownership account
+/// There could be operator relationship between subgraph owner and registered operator
+pub async fn owned_subgraphs(url: &str, account: &str) -> Result<Vec<String>, QueryError> {
+    let variables: graph_account::Variables = graph_account::Variables {
+        // Do not supply operator address if operator is already a graph account
+        operator_addr: vec![],
+        account_addr: account.to_string(),
+    };
+    let request_body = GraphAccount::build_query(variables);
+    let client = reqwest::Client::builder()
+        .user_agent("network-subgraph")
+        .build()?;
+    let request = client.post(url).json(&request_body);
+    let response = request.send().await?.error_for_status()?;
+    let response_body: Response<graph_account::ResponseData> = response.json().await?;
+    trace!(
+        result = tracing::field::debug(&response_body),
+        "Query result for graph network account"
+    );
+    if let Some(errors) = response_body.errors.as_deref() {
+        let e = &errors[0];
+        if e.message == "indexing_error" {
+            return Err(QueryError::IndexingError);
+        } else {
+            return Err(QueryError::Other(anyhow::anyhow!("{}", e.message)));
+        }
+    }
+    let data = response_body.data.ok_or_else(|| {
+        QueryError::ParseResponseError(format!(
+            "Missing response data from network subgraph for account {}",
+            account
+        ))
+    })?;
+
+    let subgraphs: Vec<String> = data
+        .graph_accounts
+        .first()
+        .map(|x| {
+            x.subgraphs
+                .iter()
+                .map(|s| s.id.clone())
+                .collect::<Vec<String>>()
+        })
+        .ok_or_else(|| {
+            QueryError::ParseResponseError(String::from(
+                "Network subgraph does not have a match for graph account",
+            ))
+        })?;
+
+    Ok(subgraphs)
+}
+
+/// Query network subgraph for subgraph ownership account
+/// There could be operator relationship between subgraph owner and registered operator
+pub async fn subgraph_hash_by_id(
+    url: &str,
+    account: &str,
+    subgraph_id: &str,
+) -> Result<Vec<String>, QueryError> {
+    let variables: graph_account::Variables = graph_account::Variables {
+        // Do not supply operator address if operator is already a graph account
+        operator_addr: vec![],
+        account_addr: account.to_string(),
+    };
+    let request_body = GraphAccount::build_query(variables);
+    let client = reqwest::Client::builder()
+        .user_agent("network-subgraph")
+        .build()?;
+    let request = client.post(url).json(&request_body);
+    let response = request.send().await?.error_for_status()?;
+    let response_body: Response<graph_account::ResponseData> = response.json().await?;
+    trace!(
+        result = tracing::field::debug(&response_body),
+        "Query result for graph network account"
+    );
+    if let Some(errors) = response_body.errors.as_deref() {
+        let e = &errors[0];
+        if e.message == "indexing_error" {
+            return Err(QueryError::IndexingError);
+        } else {
+            return Err(QueryError::Other(anyhow::anyhow!("{}", e.message)));
+        }
+    }
+    let data = response_body.data.ok_or_else(|| {
+        QueryError::ParseResponseError(format!(
+            "Missing response data from network subgraph for account {}",
+            account
+        ))
+    })?;
+
+    let hashes: Vec<String> = data
+        .graph_accounts
+        .first()
+        .map(|x| {
+            x.subgraphs
+                .iter()
+                .find_map(|s| {
+                    if s.id.clone() == subgraph_id {
+                        s.linked_entity.as_ref().map(|e| {
+                            e.versions
+                                .iter()
+                                .map(|v| v.subgraph_deployment.ipfs_hash.clone())
+                                .collect::<Vec<String>>()
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_default()
+        })
+        .ok_or_else(|| {
+            QueryError::ParseResponseError(String::from(
+                "Network subgraph does not have a match for graph account",
+            ))
+        })?;
+
+    Ok(hashes)
 }

--- a/src/graphql/client_network.rs
+++ b/src/graphql/client_network.rs
@@ -32,11 +32,12 @@ pub async fn query_network_subgraph(
         .build()?;
     let request = client.post(url).json(&request_body);
     let response = request.send().await?.error_for_status()?;
+    let response_body: Response<indexer_status::ResponseData> = response.json().await?;
     trace!(
-        result = tracing::field::debug(&response),
+        indexer_address,
+        result = tracing::field::debug(&response_body),
         "Queried result for Indexer and Network"
     );
-    let response_body: Response<indexer_status::ResponseData> = response.json().await?;
 
     if let Some(errors) = response_body.errors.as_deref() {
         let e = &errors[0];

--- a/src/graphql/query_graph_account.graphql
+++ b/src/graphql/query_graph_account.graphql
@@ -9,6 +9,13 @@ query GraphAccount($account_addr: String!, $operator_addr: [String!]!) {
     }
     subgraphs{
       id
+      linkedEntity{
+        versions {
+          subgraphDeployment{
+            ipfsHash
+          }
+        }
+      }
     }
     indexer {
       id

--- a/src/graphql/schema_graph_account.graphql
+++ b/src/graphql/schema_graph_account.graphql
@@ -1,5 +1,18 @@
 type Subgraph {
   id: String!
+  linkedEntity: LinkedEntity
+}
+
+type LinkedEntity{
+  versions: [Version!]!
+}
+
+type Version{
+  subgraphDeployment: SubgraphDeployment!
+}
+
+type SubgraphDeployment {
+  ipfsHash: String!
 }
 
 type Indexer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,10 @@ impl Account {
         Ok(!subgraph_hashes.contains(&subgraph_hash.to_string()))
     }
 
+    /// Based on id_validation mechanism, perform the corresponding check between the
+    /// message sender versus the representing graph_account.
+    ///
+    /// Currently do not verify subgraph ownership here, which should be used `IdentityValidation::SubgraphStaker`
     pub async fn verify(
         &self,
         network_subgraph: &str,
@@ -305,6 +309,9 @@ impl Account {
                 verified_account
             ))));
         };
+
+        // SubgraphStaker check for subgraph owner ship is done in Radio Level, triggered
+        // when message field provides detailed information
 
         Ok(verified_account)
     }


### PR DESCRIPTION
### Description

- id_validation variant `SubgraphStaker` allows messages verified with the identity of subgraph owner or an indexer. 
  - The specific check for subgraph ownership between subgraph and graph account can happen on the radio message type. 
  - curators and delegators not verified
- Updated `graphcast_agent` and `handle_signal` to utilize MPSC to avoid async handling of waku messages. 
- Removed `

Add function to check a graph_account is the subgraph owner for a certain deployment. 


### Issue link (if applicable)

Resolves https://github.com/graphops/graphcast-sdk/issues/254
The history of this branch is a bit messy, should rebase after merging the previous branches and make sure changes are consistent

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
