### PR TITLE
chore: update labels workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -14,4 +14,4 @@ jobs:
           actions: "add-labels"
           token: ${{ secrets.LABELS_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
-          labels: "awaiting-triage"
+          labels: "meta:awaiting-triage"


### PR DESCRIPTION
updated `awaiting-triage` to `meta:awaiting-triage`