### PR TITLE
fix: repo link in unrecognised chain message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub fn determine_message_block(
     let examination_frequency = match NETWORKS.iter().find(|n| n.name == network_name) {
         Some(n) => n.interval,
         None => {
-            let err_msg = format!("Subgraph is indexing an unsupported network {network_name}, please report an issue on https://github.com/graphops/graphcast-rs");
+            let err_msg = format!("Subgraph is indexing an unsupported network {network_name}, please report an issue on https://github.com/graphops/graphcast-sdk");
             warn!(err_msg);
             return Err(NetworkBlockError::UnsupportedNetwork(err_msg));
         }


### PR DESCRIPTION
### Description
The current error message includes a link to a repo that doesn't exist. This fixes that.

```
  2023-08-12T05:45:26.920034Z  WARN graphcast_sdk: err_msg: "Subgraph is indexing an unsupported network unknown, please report an issue on https://github.com/graphops/graphcast-rs"
    at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/graphcast-sdk-0.4.0/src/lib.rs:137
```

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
