### PR TITLE
refactor: resolve for latest deployment hash instead of a vec

### DIFF
--- a/src/graphql/query_graph_account.graphql
+++ b/src/graphql/query_graph_account.graphql
@@ -10,7 +10,7 @@ query GraphAccount($account_addr: String!, $operator_addr: [String!]!) {
     subgraphs{
       id
       linkedEntity{
-        versions {
+        currentVersion {
           subgraphDeployment{
             ipfsHash
           }

--- a/src/graphql/schema_graph_account.graphql
+++ b/src/graphql/schema_graph_account.graphql
@@ -4,7 +4,7 @@ type Subgraph {
 }
 
 type LinkedEntity{
-  versions: [Version!]!
+  currentVersion: Version
 }
 
 type Version{


### PR DESCRIPTION
### Description

We don't care about deployment hash history and would only send message to the current deployment channel, so automatically grab the current version.

### Issue link (if applicable)

To help with https://github.com/graphops/graphcast-meta/issues/17

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
