### PR TITLE
refactor: move msg channel and re-export waku msg type

### DIFF
--- a/src/graphcast_agent/waku_handling.rs
+++ b/src/graphcast_agent/waku_handling.rs
@@ -175,9 +175,11 @@ fn node_config(
     };
 
     let relay = filter_protocol.map(|b| !b);
-    debug!(
+    trace!(
         "protocols: relay {:#?}, filter {:#?}\ndiscv5_nodes: {:#?}",
-        relay, filter_protocol, discv5_nodes
+        relay,
+        filter_protocol,
+        discv5_nodes
     );
     let discv5 = Some(discv5_nodes.is_empty());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ use tracing::{debug, subscriber::SetGlobalDefaultError};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::FmtSubscriber;
 use url::{Host, Url};
+pub use waku::WakuMessage;
 use waku::WakuPubSubTopic;
 
 use crate::{graphcast_agent::ConfigError, graphql::client_registry::query_registry};


### PR DESCRIPTION
### Description

Allow more modular management of MPSC message channel and re-export WakuMessage type for the message channel

### Issue link (if applicable)

Part of https://github.com/graphops/listener-radio/issues/15
Require updates to be made for dependent radios

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
