### PR TITLE
refactor: refactor message decoding

### DIFF
--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -5,7 +5,7 @@ use dotenv::dotenv;
 use std::sync::{mpsc, Arc, Mutex};
 // Import Graphcast SDK types and functions for agent configuration, message handling, and more
 use graphcast_sdk::{
-    graphcast_agent::{GraphcastAgent, GraphcastAgentConfig},
+    graphcast_agent::{message_typing::GraphcastMessage, GraphcastAgent, GraphcastAgentConfig},
     WakuMessage,
 };
 
@@ -106,10 +106,7 @@ async fn main() {
             trace!(
                 "Radio operator received a Waku message from Graphcast agent, now try to fit it to Graphcast Message with Radio specified payload"
             );
-            let _ = GRAPHCAST_AGENT
-                .get()
-                .expect("Could not retrieve Graphcast agent")
-                .decode::<SimpleMessage>(msg.payload())
+            let _ = GraphcastMessage::<SimpleMessage>::decode(msg.payload())
                 .await
                 .map(|msg| {
                     msg.payload.radio_handler();

--- a/src/graphcast_agent/message_typing.rs
+++ b/src/graphcast_agent/message_typing.rs
@@ -286,6 +286,15 @@ impl<
             }
         }
     }
+
+    pub async fn decode(payload: &[u8]) -> Result<Self, WakuHandlingError> {
+        match <GraphcastMessage<T> as Message>::decode(payload) {
+            Ok(graphcast_message) => Ok(graphcast_message),
+            Err(e) => Err(WakuHandlingError::InvalidMessage(format!(
+                "Waku message not interpretated as a Graphcast message\nError occurred: {e:?}"
+            ))),
+        }
+    }
 }
 
 /// Check validity of the message:

--- a/src/graphcast_agent/mod.rs
+++ b/src/graphcast_agent/mod.rs
@@ -383,6 +383,7 @@ impl GraphcastAgent {
         }
     }
 
+    /// Deprecate in favor of GraphcastMessage::<T>::decode()
     pub async fn decode<T>(&self, payload: &[u8]) -> Result<GraphcastMessage<T>, WakuHandlingError>
     where
         T: Message


### PR DESCRIPTION
### Description

GraphcastMessages should be decoded without accessing a GraphcastAgent.

Left the previous methods such that there's no breaking changes for existing radios, deprecate when they move away from using `GraphcastAgent.decode::<T>`

### Issue link (if applicable)

depended by graphops/listener-radio#18

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
