### PR TITLE
chore(dep): waku version 0.3.1 for peer count fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5272,9 +5272,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "waku-bindings"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf825d80777c831d36f030029f883c5dd0fc255d0025896c67b4ba14c5ad9a"
+checksum = "ab4f521ec123865da220d0cd39f2d3deaffca80eaa32089c488ad661198a1d98"
 dependencies = [
  "aes-gcm",
  "base64 0.21.4",
@@ -5294,9 +5294,9 @@ dependencies = [
 
 [[package]]
 name = "waku-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e52e75616474f736edf5483b54448d0f9726d84cf29d07f4be5aaebb47c8749"
+checksum = "a23174a6c97644142b87cfb11e1b80b972a1d79b9260ec8ad2896775cbd45a99"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["graphprotocol", "gossip-network", "sdk", "waku", "p2p"]
 categories = ["network-programming", "web-programming::http-client"]
 
 [dependencies]
-waku = { version = "=0.3.0", package = "waku-bindings" }
+waku = { version = "=0.3.1", package = "waku-bindings" }
 slack-morphism = { version = "1.10", features = ["hyper", "axum"] }
 prost = "0.11"
 once_cell = "1.17"


### PR DESCRIPTION
### Description

This version of waku can properly get peer count for waku node


### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
