### PR TITLE
default protocol from filter to relay, additional content topic filter

### DIFF
--- a/examples/ping-pong/src/config.rs
+++ b/examples/ping-pong/src/config.rs
@@ -88,6 +88,27 @@ pub struct Config {
         indexer: must be registered at Graphcast Registry or is a Graph Account, correspond to and Indexer statisfying indexer minimum stake requirement"
     )]
     pub id_validation: IdentityValidation,
+    #[clap(
+        long,
+        value_name = "WAKU_PORT",
+        help = "Port for the Waku gossip client",
+        env = "WAKU_PORT"
+    )]
+    pub waku_port: Option<String>,
+    #[clap(
+        long,
+        value_name = "NODE_ADDRESSES",
+        help = "Comma separated static list of waku boot nodes to connect to",
+        env = "BOOT_NODE_ADDRESSES"
+    )]
+    pub boot_node_addresses: Vec<String>,
+    #[clap(
+        long,
+        value_name = "DISCV5_PORT",
+        help = "Waku node to expose discoverable udp port",
+        env = "DISCV5_PORT"
+    )]
+    pub discv5_port: Option<u16>,
 }
 
 impl Config {

--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -92,16 +92,16 @@ async fn main() {
         config.network_subgraph,
         config.id_validation.clone(),
         config.graph_node_endpoint,
-        None,
+        Some(config.boot_node_addresses),
         Some("testnet".to_string()),
         Some(subtopics),
         None,
         None,
-        None,
+        config.waku_port,
         None,
         Some(false),
         Some(vec![discovery_enr]),
-        None,
+        config.discv5_port,
     )
     .await
     .unwrap_or_else(|e| panic!("Could not create GraphcastAgentConfig: {e}"));
@@ -165,7 +165,7 @@ async fn main_loop(agent: &GraphcastAgent, running: Arc<AtomicBool>) {
                 .send_message(
                     // The identifier can be any string that suits your Radio logic
                     // If it doesn't matter for your Radio logic (like in this case), you can just use a UUID or a hardcoded string
-                    "ping-pong-content-topic",
+                    agent.content_identifiers().first().unwrap(),
                     msg,
                     Utc::now().timestamp(),
                 )
@@ -191,7 +191,7 @@ async fn main_loop(agent: &GraphcastAgent, running: Arc<AtomicBool>) {
                     // send_message(replay_msg).await;
                     if let Err(e) = agent
                         .send_message(
-                            "ping-pong-content-topic",
+                            agent.content_identifiers().first().unwrap(),
                             replay_msg,
                             Utc::now().timestamp(),
                         )

--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -99,7 +99,7 @@ async fn main() {
         None,
         None,
         None,
-        Some(true),
+        Some(false),
         Some(vec![discovery_enr]),
         None,
     )

--- a/src/graphcast_agent/mod.rs
+++ b/src/graphcast_agent/mod.rs
@@ -112,8 +112,8 @@ impl GraphcastAgentConfig {
             waku_host,
             waku_port,
             waku_addr,
-            // Extra handling here to make sure the default behavior is filter protocol enabled
-            filter_protocol: Some(filter_protocol.unwrap_or(true)),
+            // Extra handling here to make sure the default behavior is filter protocol disabled
+            filter_protocol: Some(filter_protocol.unwrap_or(false)),
             discv5_enrs: discv5_enrs.unwrap_or_default(),
             discv5_port,
         };
@@ -205,6 +205,7 @@ pub struct GraphcastAgent {
     pub seen_msg_ids: Arc<SyncMutex<HashSet<String>>>,
     /// Sender identity validation mechanism used by the Graphcast agent
     pub id_validation: IdentityValidation,
+    //TODO: Consider deprecating this field as it isn't utilized in network_check anymore
     /// Keeps track of whether Filter protocol is enabled, if false -> we're using Relay protocol
     pub filter_protocol_enabled: bool,
 }
@@ -439,8 +440,7 @@ impl GraphcastAgent {
         );
 
         // Check network before sending a message
-        network_check(&self.node_handle, self.filter_protocol_enabled)
-            .map_err(GraphcastAgentError::WakuNodeError)?;
+        network_check(&self.node_handle).map_err(GraphcastAgentError::WakuNodeError)?;
         trace!(
             address = &wallet_address(&self.graphcast_identity.wallet),
             "local sender id"

--- a/src/graphcast_agent/waku_handling.rs
+++ b/src/graphcast_agent/waku_handling.rs
@@ -487,30 +487,15 @@ pub fn peers_data(
 }
 
 /// Check for peer connectivity, try to reconnect if there are disconnected peers
-pub fn network_check(
-    node_handle: &WakuNodeHandle<Running>,
-    filter_protocol_enabled: bool,
-) -> Result<(), WakuHandlingError> {
+pub fn network_check(node_handle: &WakuNodeHandle<Running>) -> Result<(), WakuHandlingError> {
     let peers = peers_data(node_handle)?;
 
     for peer in peers.iter() {
-        let supports_filter = peer
+        if peer
             .protocols()
             .iter()
-            .any(|p| p == "/vac/waku/filter/2.0.0-beta1");
-        let supports_lightpush = peer
-            .protocols()
-            .iter()
-            .any(|p| p == "/vac/waku/lightpush/2.0.0-beta1");
-        let supports_relay = peer
-            .protocols()
-            .iter()
-            .any(|p| p == "/vac/waku/relay/2.0.0");
-
-        let should_check_filter = filter_protocol_enabled && supports_filter;
-        let should_check_relay = !filter_protocol_enabled && supports_relay;
-
-        if supports_lightpush && (should_check_filter || should_check_relay) {
+            .any(|p| p == "/vac/waku/relay/2.0.0")
+        {
             if !peer.connected() {
                 if let Err(e) = node_handle.connect_peer_with_id(peer.peer_id(), None) {
                     debug!(


### PR DESCRIPTION
### Description
- Changed default behavior of protocol participation - now radio nodes will automatically participate in relay protocol and directly subscribe and publish to relay network
- Updated network_check to connect to peers on the relay network and disregard connecting with lightpush and filter peers
- Added an additional check to only handle messages of relevant content topics
- Changed content topics to be in a std mutex instead of tokio mutex in order to use content topics upon signal handling in the waku event callback
- Updated and tested with ping-pong example

### Issue link (if applicable)
Resolves https://github.com/graphops/graphcast-sdk/issues/295

No significant updates should be needed for dependent radios

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
