### PR TITLE
GraphQL peer output helpers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,7 @@ use tracing::{debug, subscriber::SetGlobalDefaultError};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::FmtSubscriber;
 use url::{Host, Url};
-pub use waku::WakuMessage;
-use waku::WakuPubSubTopic;
+pub use waku::{WakuMessage, WakuPeerData, WakuPubSubTopic};
 
 use crate::{graphcast_agent::ConfigError, graphql::client_registry::query_registry};
 


### PR DESCRIPTION
### Description

- refactor helper functions `network_check`, `connected_peers`, `peers_data` to be part of `GraphcastAgent` struct since those functions is closely related to the responsibilities of the agent, providing more fluent interface for users of the agent struct,
- added `local_peer` helper to GraphcastAgent for accessing local peer data
- added `PeerData` GraphQL object type

### Issue link (if applicable)
Required by https://github.com/graphops/subgraph-radio/issues/106

### Checklist
- [ ] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary) -> Need to update schema in docs
