### PR TITLE
feat: add RadioPayload trait alias and requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/ping-pong/src/types.rs
+++ b/examples/ping-pong/src/types.rs
@@ -3,6 +3,9 @@ use ethers_contract::EthAbiType;
 use ethers_core::types::transaction::eip712::Eip712;
 use ethers_derive_eip712::*;
 
+use graphcast_sdk::graphcast_agent::message_typing::{
+    GraphcastMessage, MessageError, RadioPayload,
+};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 
@@ -29,6 +32,20 @@ pub struct SimpleMessage {
     pub identifier: String,
     #[prost(string, tag = "2")]
     pub content: String,
+}
+
+impl RadioPayload for SimpleMessage {
+    fn valid_outer(&self, outer: &GraphcastMessage<Self>) -> Result<&Self, MessageError> {
+        if self.identifier == outer.identifier {
+            Ok(self)
+        } else {
+            Err(MessageError::InvalidFields(anyhow::anyhow!(
+                "Radio message wrapped by inconsistent GraphcastMessage: {:#?} <- {:#?}",
+                &self,
+                &outer,
+            )))
+        }
+    }
 }
 
 impl SimpleMessage {

--- a/examples/ping-pong/src/types.rs
+++ b/examples/ping-pong/src/types.rs
@@ -22,7 +22,7 @@ pub static MESSAGES: OnceCell<Arc<Mutex<Vec<SimpleMessage>>>> = OnceCell::new();
 /// Make a test radio type
 #[derive(Eip712, EthAbiType, Clone, Message, Serialize, Deserialize, SimpleObject)]
 #[eip712(
-    name = "Graphcast Ping-Pong Radio",
+    name = "SimpleMessage",
     version = "0",
     chain_id = 1,
     verifying_contract = "0xc944e90c64b2c07662a292be6244bdf05cda44a7"

--- a/src/graphcast_agent/message_typing.rs
+++ b/src/graphcast_agent/message_typing.rs
@@ -260,12 +260,11 @@ impl<T: RadioPayload> GraphcastMessage<T> {
     }
 
     pub fn decode(payload: &[u8]) -> Result<Self, WakuHandlingError> {
-        match <GraphcastMessage<T> as Message>::decode(payload) {
-            Ok(graphcast_message) => Ok(graphcast_message),
-            Err(e) => Err(WakuHandlingError::InvalidMessage(format!(
+        <GraphcastMessage<T> as Message>::decode(payload).map_err(|e| {
+            WakuHandlingError::InvalidMessage(format!(
                 "Waku message not interpretated as a Graphcast message\nError occurred: {e:?}"
-            ))),
-        }
+            ))
+        })
     }
 }
 


### PR DESCRIPTION
### Description

Made a custom trait for more generic usage of the payload field for `GraphcastMessage`
```
pub trait RadioPayload:
    Message
    + ethers::types::transaction::eip712::Eip712<Error = Eip712Error>
    + Default
    + Clone
    + 'static
    + Serialize
    + async_graphql::OutputType 
{
  fn valid_outer(&self, outer: &GraphcastMessage<Self>) -> Result<&Self, MessageError>;
}
```

Renamed `BuildMessageError` to `MessageError` enum


### Issue link (if applicable)
Part of https://github.com/graphops/engineering-meta/issues/39

### Checklist
- [ ] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
