### PR TITLE
Add waku discovery ENR

### DIFF
--- a/examples/ping-pong/src/main.rs
+++ b/examples/ping-pong/src/main.rs
@@ -81,8 +81,6 @@ async fn main() {
     // if not provided then they are usually generated based on indexer allocations
     let subtopics: Vec<String> = vec!["ping-pong-content-topic".to_string()];
 
-    let discovery_enr = "enr:-P-4QJI8tS1WTdIQxq_yIrD05oIIW1Xg-tm_qfP0CHfJGnp9dfr6ttQJmHwTNxGEl4Le8Q7YHcmi-kXTtphxFysS11oBgmlkgnY0gmlwhLymh5GKbXVsdGlhZGRyc7hgAC02KG5vZGUtMDEuZG8tYW1zMy53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGdl8ALzYobm9kZS0wMS5kby1hbXMzLndha3V2Mi5wcm9kLnN0YXR1c2ltLm5ldAYfQN4DiXNlY3AyNTZrMaEDbl1X_zJIw3EAJGtmHMVn4Z2xhpSoUaP5ElsHKCv7hlWDdGNwgnZfg3VkcIIjKIV3YWt1Mg8".to_string();
-
     // GraphcastAgentConfig defines the configuration that the SDK expects from all Radios, regardless of their specific functionality
     let graphcast_agent_config = GraphcastAgentConfig::new(
         config.private_key.expect("No private key provided"),
@@ -100,7 +98,7 @@ async fn main() {
         config.waku_port,
         None,
         Some(false),
-        Some(vec![discovery_enr]),
+        None,
         config.discv5_port,
     )
     .await

--- a/src/graphcast_agent/mod.rs
+++ b/src/graphcast_agent/mod.rs
@@ -47,6 +47,9 @@ pub mod waku_handling;
 /// A constant defining a message expiration limit.
 pub const MSG_REPLAY_LIMIT: u64 = 3_600_000;
 
+// Waku discovery network
+pub const WAKU_DISCOVERY_ENR: &str = "enr:-P-4QJI8tS1WTdIQxq_yIrD05oIIW1Xg-tm_qfP0CHfJGnp9dfr6ttQJmHwTNxGEl4Le8Q7YHcmi-kXTtphxFysS11oBgmlkgnY0gmlwhLymh5GKbXVsdGlhZGRyc7hgAC02KG5vZGUtMDEuZG8tYW1zMy53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGdl8ALzYobm9kZS0wMS5kby1hbXMzLndha3V2Mi5wcm9kLnN0YXR1c2ltLm5ldAYfQN4DiXNlY3AyNTZrMaEDbl1X_zJIw3EAJGtmHMVn4Z2xhpSoUaP5ElsHKCv7hlWDdGNwgnZfg3VkcIIjKIV3YWt1Mg8";
+
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
     #[error("Validate the input: {0}")]
@@ -100,6 +103,8 @@ impl GraphcastAgentConfig {
         let boot_node_addresses = convert_to_multiaddrs(&boot_node_addresses.unwrap_or_default())
             .map_err(|_| GraphcastAgentError::ConvertMultiaddrError)?;
 
+        let discv5_enrs = discv5_enrs.unwrap_or(vec![WAKU_DISCOVERY_ENR.to_string()]);
+
         let config = GraphcastAgentConfig {
             wallet_key,
             graph_account,
@@ -117,7 +122,7 @@ impl GraphcastAgentConfig {
             waku_addr,
             // Extra handling here to make sure the default behavior is filter protocol disabled
             filter_protocol: Some(filter_protocol.unwrap_or(false)),
-            discv5_enrs: discv5_enrs.unwrap_or_default(),
+            discv5_enrs,
             discv5_port,
         };
 


### PR DESCRIPTION
Bringing the Waku discovery ENR back to the SDK, it will be used if the `discv5_port` config variable is provided.
Accompanying PR - https://github.com/graphops/subgraph-radio/pull/120